### PR TITLE
Fix merging pull-request with no discussion fails

### DIFF
--- a/src/Cli/Handler/MergeHandler.php
+++ b/src/Cli/Handler/MergeHandler.php
@@ -323,7 +323,10 @@ COMMENT;
         // could be stale.
         $this->git->remoteUpdate('upstream');
         $this->git->addNotes($commentText, $sha, 'github-comments');
-        $this->git->pushToRemote('upstream', 'refs/notes/github-comments');
+
+        if ('' !== $commentText) {
+            $this->git->pushToRemote('upstream', 'refs/notes/github-comments');
+        }
     }
 
     private function updateLocalBranch(string $branch)

--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -246,6 +246,11 @@ class Git
         $tmpName = $this->filesystem->newTempFilename();
         file_put_contents($tmpName, $notes);
 
+        // Cannot add empty notes
+        if ('' === trim($notes)) {
+            return;
+        }
+
         $commands = [
             'git',
             'notes',

--- a/tests/Handler/MergeHandlerTest.php
+++ b/tests/Handler/MergeHandlerTest.php
@@ -999,7 +999,10 @@ BODY
         $this->git->ensureNotesFetching('upstream')->shouldBeCalled();
         $this->git->remoteUpdate('upstream')->shouldBeCalled();
         $this->git->addNotes($notesMessage ? PropArgument::containingString($notesMessage) : '', self::MERGE_SHA, 'github-comments')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', 'refs/notes/github-comments')->shouldBeCalled();
+
+        if ('' !== $notesMessage) {
+            $this->git->pushToRemote('upstream', 'refs/notes/github-comments')->shouldBeCalled();
+        }
     }
 
     private function expectLocalUpdate(bool $ready = true, bool $branchExists = true)


### PR DESCRIPTION
Problem: When there are no notes yet, pushing empty notes causes Git to error.

Solution: Check there are actually comments before pushing notes.