### PR TITLE
Allow releases based on relative versions

### DIFF
--- a/src/Cli/Handler/ReleaseHandler.php
+++ b/src/Cli/Handler/ReleaseHandler.php
@@ -109,7 +109,11 @@ final class ReleaseHandler extends GitBaseHandler
 
     private function validateVersion(string $version): Version
     {
-        $version = Version::fromString($version);
+        if (in_array(strtolower($version), ['alpha', 'beta', 'rc', 'stable', 'major', 'minor', 'patch'], true)) {
+            $version = Version::fromString($this->git->getLastTagOnBranch())->increase(strtolower($version));
+        } else {
+            $version = Version::fromString($version);
+        }
 
         if (!$this->io->isInteractive()) {
             return $version;

--- a/src/Cli/HubKitApplicationConfig.php
+++ b/src/Cli/HubKitApplicationConfig.php
@@ -225,7 +225,7 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
 
             ->beginCommand('release')
                 ->setDescription('Make a new release for the current branch')
-                ->addArgument('version', Argument::REQUIRED | Argument::STRING, 'Version to make')
+                ->addArgument('version', Argument::REQUIRED | Argument::STRING, 'Version to make (supports relative, eg. minor, alpha, ...)')
                 ->addOption('all-categories', null, Option::NO_VALUE | Option::BOOLEAN, 'Show all categories (including empty)')
                 ->addOption('no-edit', null, Option::NO_VALUE | Option::BOOLEAN, 'Don\'t open the editor for editing the release page')
                 ->addOption('pre-release', null, Option::NO_VALUE | Option::BOOLEAN, 'Mark as pre-release (not production ready)')

--- a/src/Helper/Version.php
+++ b/src/Helper/Version.php
@@ -203,7 +203,12 @@ final class Version
                 return $this->increaseStable();
 
             default:
-                throw new \InvalidArgumentException('Unknown or unsupported stability provided: '.$stability);
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Unknown stability "%s", accepts "%s" '.$stability,
+                        implode('", "', ['alpha', 'beta', 'rc', 'stable', 'major', 'minor', 'patch'])
+                    )
+                );
         }
     }
 

--- a/src/Helper/Version.php
+++ b/src/Helper/Version.php
@@ -162,4 +162,70 @@ final class Version
     {
         return $this->full === $second->full;
     }
+
+    /**
+     * Returns the increased Version based on the stability.
+     *
+     * Note. Using 'major' on a beta release will create a stable release
+     * for that major version. Using 'stable' on an existing stable will increase
+     * minor.
+     *
+     * @param string $stability Eg. alpha, beta, rc, stable, major, minor, patch
+     *
+     * @return Version A new version instance with the changes applied
+     */
+    public function increase(string $stability): Version
+    {
+        switch ($stability) {
+            case 'patch':
+                if ($this->major > 0 && $this->metaver > 0) {
+                    throw new \InvalidArgumentException('Cannot increase patch for an unstable version.');
+                }
+
+                return new self($this->major, $this->minor, $this->patch + 1, 3);
+
+            case 'minor':
+                return new self($this->major, $this->minor + 1, 0, 3);
+
+            case 'major':
+                if ($this->stability < 3) {
+                    return new self($this->major > 0 ? $this->major : $this->major + 1, 0, 0, 3);
+                }
+
+                return new self($this->major + 1, 0, 0, 3);
+
+            case 'alpha':
+            case 'beta':
+            case 'rc':
+                return $this->increaseMetaver($stability);
+
+            case 'stable':
+                return $this->increaseStable();
+
+            default:
+                throw new \InvalidArgumentException('Unknown or unsupported stability provided: '.$stability);
+        }
+    }
+
+    private function increaseMetaver(string $stability): Version
+    {
+        if ($this->stability === self::$stabilises[$stability]) {
+            return new self($this->major, $this->minor, 0, $this->stability, $this->metaver + 1);
+        }
+
+        if (self::$stabilises[$stability] > $this->stability) {
+            return new self($this->major, $this->minor, 0, self::$stabilises[$stability], 1);
+        }
+
+        return new self($this->major, $this->minor + 1, 0, self::$stabilises[$stability], 1);
+    }
+
+    private function increaseStable(): Version
+    {
+        if ($this->stability < 3) {
+            return new self(max($this->major, 1), 0, 0, 3);
+        }
+
+        return new self($this->major, $this->minor + 1, 0, 3);
+    }
 }

--- a/tests/Handler/ReleaseHandlerTest.php
+++ b/tests/Handler/ReleaseHandlerTest.php
@@ -259,6 +259,32 @@ labels: removed-deprecation
         $this->executeHandler($args); // default answer is no
     }
 
+    /** @test */
+    public function it_creates_a_new_release_with_a_relative_version()
+    {
+        $this->expectTags(['0.1.0', '1.0.0', '2.0.0']);
+        $this->git->getLastTagOnBranch()->willReturn('2.5.0');
+        $this->expectMatchingVersionBranchNotExists('3.0');
+
+        $this->git->getLogBetweenCommits('2.5.0', 'master')->willReturn(self::COMMITS);
+
+        $this->expectEditorReturns("### Added\n- Introduce a new API for ValuesBag", 'Drop support for older PHP versions');
+
+        $url = $this->expectTagAndGitHubRelease('3.0.0', 'Drop support for older PHP versions');
+
+        $args = $this->getArgs('major');
+        $this->executeHandler($args);
+
+        $this->assertOutputMatches(
+            [
+                'Preparing release 3.0.0 (target branch master)',
+                'Please wait...',
+                'Successfully released 3.0.0',
+                $url,
+            ]
+        );
+    }
+
     private function getArgs(string $version): Args
     {
         $format = ArgsFormat::build()


### PR DESCRIPTION
Allow `alpha | beta | rc | patch | minor | major | stable` as version for release command.

Closes #19