### PR TITLE
Fix Git::getRemoteDiffStatus with slashed branch

### DIFF
--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -72,8 +72,8 @@ class Git
         }
 
         $localRef = $this->process->mustRun(['git', 'rev-parse', $localBranch])->getOutput();
-        $remoteRef = $this->process->mustRun(['git', 'rev-parse', $remoteName.'/'.$remoteBranch])->getOutput();
-        $baseRef = $this->process->mustRun(['git', 'merge-base', $remoteBranch, $remoteName.'/'.$remoteBranch])->getOutput();
+        $remoteRef = $this->process->mustRun(['git', 'rev-parse', 'refs/remotes/'.$remoteName.'/'.$remoteBranch])->getOutput();
+        $baseRef = $this->process->mustRun(['git', 'merge-base', $localBranch, 'refs/remotes/'.$remoteName.'/'.$remoteBranch])->getOutput();
 
         if ($localRef === $remoteRef) {
             return self::STATUS_UP_TO_DATE;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Git doesn’t work well with slashes in the branch name, use the full ref path to make this work.