### PR TITLE
Monolith repository splitting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
     - if [[ $coverage = 1 ]]; then wget https://phar.phpunit.de/phpcov.phar; fi
     - if [[ $coverage = 1 ]]; then wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar; fi
     - if [[ $lint = 1 ]]; then wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.3.2/php-cs-fixer.phar; fi
-    - if [[ $lint = 1 ]]; then composer global require phpstan/phpstan; fi
+    - if [[ $lint = 1 ]]; then composer global require phpstan/phpstan:"^0.8.0"; fi
     - export PATH="$PATH:$HOME/.composer/vendor/bin:./vendor/bin"
 
 install:

--- a/config.php.dist
+++ b/config.php.dist
@@ -21,4 +21,27 @@ return [
 //            'api_url' => 'https://api.hub.mycorp.com/' // schema + hostname to API endpoint (excluding API version)
 //        ],
     ],
+
+    // Configuration for repository splitting.
+    // Structure is expected to be: [hostname][organization/source-repository]
+    // With 'split' being a list of paths (relative to repository root, and no patterns)
+    //    and the value e.g. an 'push url' or `['url' => 'push url', 'sync-tags' => false]`.
+    //
+    // All configured targets are split when requested. Missing directories are ignored.
+    //
+    // The push remote is automatically registered.
+    // The 'sync-tags' can be configured for all split targets, and per target.
+    //
+//    'repos' => [
+//        'github.com' => [
+//            'park-manager/park-manager' => [
+//                'sync-tags' => true,
+//                'split' => [
+//                    'src/Bundle/CoreBundle' => 'git@github.com:park-manager/core-bundle.git',
+//                    'src/Bundle/UserBundle' => 'git@github.com:park-manager/user-bundle.git',
+//                    'doc' => ['git@github.com:park-manager/doc.git', 'sync-tags' => false],
+//                ],
+//            ],
+//        ],
+//    ],
 ];

--- a/src/Cli/Handler/SplitRepoHandler.php
+++ b/src/Cli/Handler/SplitRepoHandler.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HubKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Cli\Handler;
+
+use HubKit\Config;
+use HubKit\Service\Git;
+use HubKit\Service\GitHub;
+use HubKit\Service\SplitshGit;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Console\Api\Args\Args;
+
+final class SplitRepoHandler extends GitBaseHandler
+{
+    private $splitshGit;
+    private $config;
+
+    public function __construct(SymfonyStyle $style, SplitshGit $splitshGit, Git $git, GitHub $github, Config $config)
+    {
+        parent::__construct($style, $git, $github);
+        $this->splitshGit = $splitshGit;
+        $this->config = $config;
+    }
+
+    public function handle(Args $args): int
+    {
+        $this->git->guardWorkingTreeReady();
+        $this->git->remoteUpdate('upstream');
+
+        $configName = ['repos', $this->github->getHostname(), $this->github->getOrganization().'/'.$this->github->getRepository(), 'split'];
+        $config = $this->config->get($configName);
+
+        if (null === $config) {
+            $this->style->error(
+                sprintf('Unable to split repository: No targets were found in config "[%s]", update the configuration file.', implode('][', $configName))
+            );
+
+            return 2;
+        }
+
+        if (null === $branch = $args->getArgument('branch')) {
+            $branch = $this->git->getActiveBranchName();
+        } else {
+            $this->git->checkoutRemoteBranch('upstream', $branch);
+        }
+
+        $this->style->title('Repository Split');
+        $this->informationHeader($branch);
+
+        if ($args->getOption('dry-run')) {
+            return $this->drySplitRepository($branch, $config);
+        }
+
+        return $this->splitRepository($branch, $config);
+    }
+
+    private function splitRepository(string $branch, array $repos): int
+    {
+        $this->git->ensureBranchInSync('upstream', $branch);
+        $this->splitshGit->checkPrecondition();
+
+        $this->style->section(sprintf('%s sources to split', count($repos)));
+
+        foreach ($repos as $prefix => $config) {
+            $url = is_array($config) ? $config['url'] : $config;
+
+            $this->style->writeln(sprintf('<fg=default;bg=default> Splitting %s to %s</>', $prefix, $url));
+            $this->splitshGit->splitTo($branch, $prefix, $url);
+        }
+
+        $this->style->success('Repository directories were split into there destination.');
+
+        return 0;
+    }
+
+    private function drySplitRepository(string $branch, array $repos): int
+    {
+        $this->git->ensureBranchInSync('upstream', $branch);
+        $this->splitshGit->checkPrecondition();
+
+        $this->style->section(sprintf('%s sources to split', count($repos)));
+
+        foreach ($repos as $prefix => $config) {
+            $this->style->writeln(sprintf('<fg=default;bg=default> [DRY-RUN] Splitting %s to %s</>', $prefix,
+                is_array($config) ? $config['url'] : $config
+            ));
+        }
+
+        $this->style->newLine();
+        $this->style->success('[DRY-RUN] Repository directories were split into there destination.');
+
+        return 0;
+    }
+}

--- a/src/Cli/HubKitApplicationConfig.php
+++ b/src/Cli/HubKitApplicationConfig.php
@@ -207,7 +207,9 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
                         $this->container['git'],
                         $this->container['github'],
                         new BranchAliasResolver($this->container['style'], $this->container['git'], getcwd()),
-                        new SingleLineChoiceQuestionHelper()
+                        new SingleLineChoiceQuestionHelper(),
+                        $this->container['config'],
+                        $this->container['splitsh_git']
                     );
                 })
             ->end()

--- a/src/Cli/HubKitApplicationConfig.php
+++ b/src/Cli/HubKitApplicationConfig.php
@@ -277,7 +277,9 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
                         $this->container['git'],
                         $this->container['github'],
                         $this->container['process'],
-                        $this->container['editor']
+                        $this->container['editor'],
+                        $this->container['config'],
+                        $this->container['splitsh_git']
                     );
                 })
             ->end()

--- a/src/Cli/HubKitApplicationConfig.php
+++ b/src/Cli/HubKitApplicationConfig.php
@@ -152,6 +152,21 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
                 })
             ->end()
 
+            ->beginCommand('split-repo')
+                ->setDescription('Split the repository into configured targets. Requires "repos" is configured in config.php')
+                ->addArgument('branch', Argument::OPTIONAL | Argument::STRING, 'Branch to checkout and split from, uses current when omitted')
+                ->addOption('dry-run', null, Option::NO_VALUE | Option::BOOLEAN, 'Show which operations would have been performed (without actually splitting)')
+                ->setHandler(function () {
+                    return new Handler\SplitRepoHandler(
+                        $this->container['style'],
+                        $this->container['splitsh_git'],
+                        $this->container['git'],
+                        $this->container['github'],
+                        $this->container['config']
+                    );
+                })
+            ->end()
+
             ->beginCommand('take')
                 ->setDescription('Take an issue to work on, checks out the issue as new branch.')
                 ->addArgument('number', Argument::INTEGER, 'Number of the issue to take')

--- a/src/Container.php
+++ b/src/Container.php
@@ -16,6 +16,7 @@ namespace HubKit;
 use GuzzleHttp\Client as GuzzleClient;
 use Http\Adapter\Guzzle6\Client as GuzzleClientAdapter;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\ExecutableFinder;
 
 class Container extends \Pimple\Container
 {
@@ -47,6 +48,15 @@ class Container extends \Pimple\Container
 
         $this['git'] = function (Container $container) {
             return new Service\Git($container['process'], $container['filesystem'], $container['style']);
+        };
+
+        $this['splitsh_git'] = function (Container $container) {
+            return new Service\SplitshGit(
+                $container['git'],
+                $container['process'],
+                $container['filesystem'],
+                (new ExecutableFinder())->find('splitsh-lite')
+            );
         };
 
         $this['filesystem'] = function () {

--- a/src/Service/Filesystem.php
+++ b/src/Service/Filesystem.php
@@ -42,6 +42,20 @@ class Filesystem
         return $tmpName;
     }
 
+    public function tempDirectory(string $name, bool $clearExisting = true): string
+    {
+        $tmpName = $this->tempdir.DIRECTORY_SEPARATOR.'hubkit'.DIRECTORY_SEPARATOR.$name;
+
+        if ($clearExisting && $this->fs->exists($tmpName)) {
+            $this->fs->remove($tmpName);
+        }
+
+        $this->fs->mkdir($tmpName);
+        $this->tempFilenames[] = $tmpName;
+
+        return $tmpName;
+    }
+
     /**
      * Remove all the temp-file that were created
      * with newTempFilename().
@@ -49,5 +63,15 @@ class Filesystem
     public function clearTempFiles()
     {
         $this->fs->remove($this->tempFilenames);
+    }
+
+    public function getFilesystem(): SfFilesystem
+    {
+        return $this->fs;
+    }
+
+    public function chdir(string $directory): bool
+    {
+        return chdir($directory);
     }
 }

--- a/src/Service/SplitshGit.php
+++ b/src/Service/SplitshGit.php
@@ -72,7 +72,7 @@ class SplitshGit
      * Existing tags are silently ignored.
      *
      * @param string $versionStr Version (without prefix) for the tag name
-     * @param array  $targets    Targets to tag and push as ['remote-name' => 'sha1-hash']
+     * @param array  $targets    Targets to tag and push as ['remote-name' => ['sha1-hash', 'url', 'commits count']]
      */
     public function syncTags(string $versionStr, string $branch, array $targets): void
     {

--- a/src/Service/SplitshGit.php
+++ b/src/Service/SplitshGit.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HubKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Service;
+
+class SplitshGit
+{
+    private $git;
+    private $process;
+    private $executable;
+    private $filesystem;
+
+    public function __construct(Git $git, CliProcess $process, Filesystem $filesystem, ?string $executable)
+    {
+        $this->git = $git;
+        $this->process = $process;
+        $this->filesystem = $filesystem;
+        $this->executable = $executable;
+    }
+
+    /**
+     * Split the prefix directory into another repository.
+     *
+     * Returns information of the spit in the following format:
+     * [remote-name => [sha1, git-url, commits-count]]
+     *
+     * The sha1 hash is the last commit, even when when no (new) commits
+     * were detected.
+     *
+     * Note: When the prefix directory doesn't exist it's ignored (returns null).
+     *
+     * @param string $targetBranch Target branch to push to
+     * @param string $prefix       Directory prefix, relative to the root directory
+     * @param string $url          Git supported URL for pushing the commits
+     *
+     * @return array|null Information of the split or null when prefix doesn't exist
+     */
+    public function splitTo(string $targetBranch, string $prefix, string $url): ?array
+    {
+        if (!file_exists(getcwd().'/'.$prefix) || !is_dir(getcwd().'/'.$prefix)) {
+            return null;
+        }
+
+        $process = $this->process->mustRun([$this->executable, '--prefix', $prefix]);
+        $commits = (int) explode(' ', trim($process->getErrorOutput()))[0];
+        $sha = trim($process->getOutput());
+
+        $remoteName = '_'.Git::getGitUrlInfo($url)['repo'];
+        $this->git->ensureRemoteExists($remoteName, $url);
+
+        if ($commits > 0) {
+            $this->git->pushToRemote($remoteName, $sha.':'.$targetBranch);
+        }
+
+        return [$remoteName => [$sha, $url, $commits]];
+    }
+
+    /**
+     * Synchronize the source tag to split repositories.
+     *
+     * This method re-uses the information provided by splitTo().
+     * Existing tags are silently ignored.
+     *
+     * @param string $versionStr Version (without prefix) for the tag name
+     * @param array  $targets    Targets to tag and push as ['remote-name' => 'sha1-hash']
+     */
+    public function syncTags(string $versionStr, string $branch, array $targets): void
+    {
+        $tempDir = $this->filesystem->tempDirectory('split');
+        $filesystem = $this->filesystem->getFilesystem();
+        $currentDir = getcwd();
+
+        // Create a temp clone of the split-repository and tag a release (specific to the split).
+        // All temp directories are automatically removed afterwards.
+
+        foreach ($targets as $remote => list($targetCommit, $url)) {
+            $filesystem->mkdir($tempDir.'/'.$remote);
+
+            if (!$this->filesystem->chdir($tempDir.'/'.$remote)) {
+                throw new \RuntimeException('Unable to change to temp repository. Aborting.');
+            }
+
+            $this->git->clone($url, 'origin', 200);
+            $this->git->checkout($branch);
+
+            try {
+                $this->process->mustRun(['git', 'tag', 'v'.$versionStr, $targetCommit, '-s', '-m', 'Release '.$versionStr]);
+            } catch (\Exception $e) {
+                // no-op. Ignore and try to push.
+            }
+
+            $this->process->run(['git', 'push', '--tags', 'origin']);
+        }
+
+        $this->filesystem->chdir($currentDir);
+    }
+
+    public function checkPrecondition(): void
+    {
+        if (null === $this->executable) {
+            throw new \RuntimeException('Unable to find "splitsh-lite" in PATH.');
+        }
+
+        if (!$this->git->isGitDir()) {
+            throw new \RuntimeException(
+                'Unable to perform split operation. Requires Git root directory of the repository.'
+            );
+        }
+    }
+}

--- a/tests/Service/Fixtures/src/Bundle/CoreBundle/.gitkeep
+++ b/tests/Service/Fixtures/src/Bundle/CoreBundle/.gitkeep
@@ -1,0 +1,1 @@
+Your the keeper of the 7 keys.

--- a/tests/Service/SplitshGitTest.php
+++ b/tests/Service/SplitshGitTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HubKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Tests\Service;
+
+use HubKit\Service\CliProcess;
+use HubKit\Service\Filesystem;
+use HubKit\Service\Git;
+use HubKit\Service\SplitshGit;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem as SfFilesystem;
+use Symfony\Component\Process\Process;
+
+class SplitshGitTest extends TestCase
+{
+    private const SPLITSH_EXECUTABLE = '/usr/locale/bin/splitsh-lite';
+
+    /** @test */
+    public function it_splits_source_into_target()
+    {
+        $pwd = getcwd();
+
+        try {
+            chdir(__DIR__.'/Fixtures');
+
+            $gitProphecy = $this->prophesize(Git::class);
+            $gitProphecy->isGitDir()->willReturn(true);
+            $gitProphecy->ensureRemoteExists('_core', 'git@github.com:park-manager/core.git')->shouldBeCalled();
+            $gitProphecy->pushToRemote('_core', '2c00338aef823d0c0916fc1b59ef49d0bb76f02f:master')->shouldBeCalled();
+            $git = $gitProphecy->reveal();
+
+            $processProphecy = $this->prophesize(Process::class);
+            $processProphecy->getOutput()->willReturn('2c00338aef823d0c0916fc1b59ef49d0bb76f02f');
+            $processProphecy->getErrorOutput()->willReturn("\n5 commits created, 0 commits traversed, in 7ms");
+
+            $processCliProphecy = $this->prophesize(CliProcess::class);
+            $processCliProphecy->mustRun([self::SPLITSH_EXECUTABLE, '--prefix', 'src/Bundle/CoreBundle'])->willReturn(
+                $processProphecy->reveal()
+            );
+            $cliProcess = $processCliProphecy->reveal();
+
+            $filesystemProphecy = $this->prophesize(Filesystem::class);
+            $filesystem = $filesystemProphecy->reveal();
+
+            $service = new SplitshGit($git, $cliProcess, $filesystem, self::SPLITSH_EXECUTABLE);
+
+            self::assertEquals(
+                ['_core' => ['2c00338aef823d0c0916fc1b59ef49d0bb76f02f', 'git@github.com:park-manager/core.git', 5]],
+                $service->splitTo('master', 'src/Bundle/CoreBundle', 'git@github.com:park-manager/core.git')
+            );
+        } finally {
+            chdir($pwd);
+        }
+    }
+
+    /** @test */
+    public function it_syncs_tag_into_targets()
+    {
+        $gitProphecy = $this->prophesize(Git::class);
+        $gitProphecy->getGitConfig('remote._core.url')->willReturn('git@github.com:park-manager/core.git');
+        $gitProphecy->getGitConfig('remote._user.url')->willReturn('git@github.com:park-manager/user.git');
+        $gitProphecy->clone('git@github.com:park-manager/core.git', 'origin', 200)->shouldBeCalledTimes(1);
+        $gitProphecy->clone('git@github.com:park-manager/user.git', 'origin', 200)->shouldBeCalledTimes(1);
+        $gitProphecy->checkout('1.0')->shouldBeCalledTimes(2);
+
+        $git = $gitProphecy->reveal();
+
+        $processCliProphecy = $this->prophesize(CliProcess::class);
+        $processCliProphecy->mustRun(['git', 'tag', 'v1.0.0', '2c00338aef823d0c0916fc1b59ef49d0bb76f02f', '-s', '-m', 'Release 1.0.0'])->shouldBeCalledTimes(1);
+        $processCliProphecy->mustRun(['git', 'tag', 'v1.0.0', '3eed8083737422fe9ac2da9f4348423089fceb7f', '-s', '-m', 'Release 1.0.0'])->shouldBeCalledTimes(1);
+        $processCliProphecy->run(['git', 'push', '--tags', 'origin'])->shouldBeCalledTimes(2);
+        $cliProcess = $processCliProphecy->reveal();
+
+        $sfFilesystemProphecy = $this->prophesize(SfFilesystem::class);
+        $sfFilesystemProphecy->mkdir('/tmp/hubkit/split/_core')->shouldBeCalledTimes(1);
+        $sfFilesystemProphecy->mkdir('/tmp/hubkit/split/_user')->shouldBeCalledTimes(1);
+
+        $filesystemProphecy = $this->prophesize(Filesystem::class);
+        $filesystemProphecy->tempDirectory('split')->willReturn('/tmp/hubkit/split');
+        $filesystemProphecy->chdir('/tmp/hubkit/split/_core')->willReturn(true)->shouldBeCalledTimes(1);
+        $filesystemProphecy->chdir('/tmp/hubkit/split/_user')->willReturn(true)->shouldBeCalledTimes(1);
+        $filesystemProphecy->chdir(getcwd())->willReturn(true)->shouldBeCalledTimes(1);
+        $filesystemProphecy->getFilesystem()->willReturn($sfFilesystemProphecy->reveal());
+        $filesystem = $filesystemProphecy->reveal();
+
+        $service = new SplitshGit($git, $cliProcess, $filesystem, self::SPLITSH_EXECUTABLE);
+
+        $service->syncTags(
+            '1.0.0',
+            '1.0',
+            [
+                '_core' => ['2c00338aef823d0c0916fc1b59ef49d0bb76f02f', 'git@github.com:park-manager/core.git', 5],
+                '_user' => ['3eed8083737422fe9ac2da9f4348423089fceb7f', 'git@github.com:park-manager/user.git', 3],
+            ]
+        );
+    }
+
+    /** @test */
+    public function it_checks_precondition()
+    {
+        $gitProphecy = $this->prophesize(Git::class);
+        $gitProphecy->isGitDir()->willReturn(true);
+        $git = $gitProphecy->reveal();
+
+        $service = new SplitshGit(
+            $git,
+            $this->createMock(CliProcess::class),
+            $this->createMock(Filesystem::class),
+            self::SPLITSH_EXECUTABLE
+        );
+        $service->checkPrecondition();
+    }
+
+    /** @test */
+    public function it_requires_root_directory_as_precondition()
+    {
+        $gitProphecy = $this->prophesize(Git::class);
+        $gitProphecy->isGitDir()->willReturn(false);
+        $git = $gitProphecy->reveal();
+
+        $service = new SplitshGit(
+            $git,
+            $this->createMock(CliProcess::class),
+            $this->createMock(Filesystem::class),
+            self::SPLITSH_EXECUTABLE
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to perform split operation. Requires Git root directory of the repository.');
+
+        $service->checkPrecondition();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Working with monolith development repositories (not distribution) can be quite complex, and requires an infrastructure to handle the splitting of directories and synchronizing tags.

See also: https://www.tomasvotruba.cz/blog/2017/01/31/how-monolithic-repository-in-open-source-saved-my-laziness/ and newer https://www.tomasvotruba.cz/blog/2017/10/30/what-can-you-learn-from-menstruation-and-symfony-releases/

## Splitsh

Splitsh-lite created by Fabien Potencier provides powerful and super easy to use program for splitting commits (based on) into other branches, and with some manual work to other repositories.

But for a daily operation one properly ones some automatization, and don't have write a fragile bash script. While Fabien provides hosting of the infrastructure (for some projects) this will not work for private projects, or projects whose structure is not final yet (like Park-Manager :)).

## Repo-split

Long story short, HubKit now allows to split a monolith repository into READ-ONLY repositories.
After a merge operation, manually or when making a new release! _splitting in upmere is planned for later._

The configuration needs to be stored globally in `config.php` (as keeping this per branch makes configuration management fragile). So for the future I hope to find a better solution. 

Tags are automatically synchronized (can be disabled per monolith repository or target).

**Important!:** Automatically splitting after merges and during releases is only possible when using HubKit! Using the GitHub merge-button does not split the repository, you need to perform the `split-repo` command afterwards then.

Todo:

- [ ] Update documentation
- [x] Review all changes
- [x] Clean-up some comments and improve error handling