### PR TITLE
[Release] add support for pre/post scripts

### DIFF
--- a/.hubkit/pre-release.php
+++ b/.hubkit/pre-release.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Psr\Container\ContainerInterface as Container;
+use Rollerworks\Component\Version\Version;
+
+return function (Container $container, Version $version, string $branch, ?string $releaseTitle, string $changelog) {
+
+    $container->get('logger')->info('Updating composer branch-alias');
+    $container->get('process')->mustRun(['composer', 'config', 'extra.branch-alias.dev-'.$branch, sprintf('%d.%d-dev', $version->major, $version->minor)]);
+
+    /** @var \HubKit\Service\Git\GitBranch $gitBranch */
+    $gitBranch = $container->get('git.branch');
+
+    if ($gitBranch->isWorkingTreeReady()) {
+        return; // Nothing to, composer is already up-to-date
+    }
+
+    $gitBranch->add('composer.json');
+    $gitBranch->commit('Update composer branch-alias');
+
+    /** @var \HubKit\Service\Git $git */
+    $git = $container->get('git.branch');
+    $git->pushToRemote('upstream', $branch);
+};

--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,10 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0"
+        }
+    }
 }

--- a/docs/release-hooks.md
+++ b/docs/release-hooks.md
@@ -1,0 +1,194 @@
+Release hooks
+=============
+
+The `release` command makes a new release for the current branch. By default this creates
+a new signed Git tag, published a GitHub release page, and updates the split repositories.
+
+But sometimes you need to perform a special operation before and/or after the release process.
+This might vary from updating the `composer.json` branch-alias, to creating a pull request for 
+the new release.
+
+Now instead of doing this manually Hubkit allows to hook-into the release process, but executing
+a custom script before and/or after a new release created.
+
+Both the pre and post hooks work the same way, but are executed at different stages.
+
+## The Script
+
+Add a PHP  script named either `pre-release.php` or `post-release.php` in the project root folder 
+at `.hubkit`, like `.hubkit/pre-release.php`.
+
+With the following contents:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Psr\Container\ContainerInterface as Container;
+use Rollerworks\Component\Version\Version;
+
+return function (Container $container, Version $version, string $branch, ?string $releaseTitle, string $changelog) {
+    // Place the hooks logic here.
+    
+    // The $container provides access to the Hubkit application Service Container
+    // with among following services: github, git (git.config, git.branch), process, filesystem, style, editor, logger.
+    // 
+    // See \HubKit\Container for all services and there corresponding classes.
+    // Note: Only the services listed above are covered by the BC promise. 
+};
+```
+
+**Note:** The hook is executed in the application's context, you have full access to entire applications flow!
+
+Below you can find some examples how to use these hooks
+
+### Updating the `composer.json` branch-alias (pre-release)
+
+```php
+<?php
+
+declare(strict_types=1);
+
+// .hubkit/pre-release.php
+
+use Psr\Container\ContainerInterface as Container;
+use Rollerworks\Component\Version\Version;
+
+return function (Container $container, Version $version, string $branch, ?string $releaseTitle, string $changelog) {
+    
+    $container->get('logger')->info('Updating composer branch-alias');
+    $container->get('process')->mustRun(['composer', 'config', 'extra.branch-alias.dev-'.$branch, sprintf('%d.%d-dev', $version->major, $version->minor)]);
+    
+    // Caution: Make sure to commit the changes. Hubkit will refuse to continue if there are dangling changes.
+    
+    /** @var \HubKit\Service\Git\GitBranch $gitBranch */
+    $gitBranch = $container->get('git.branch');
+    
+    $gitBranch->add('composer.json');
+    $gitBranch->commit('Update composer branch-alias');
+    
+    /** @var \HubKit\Service\Git $git */
+    $git = $container->get('git.branch');
+    $git->pushToRemote('upstream', $branch);
+};
+```
+
+### Updating the `composer.json` branch-alias
+
+```php
+<?php
+
+declare(strict_types=1);
+
+// .hubkit/pre-release.php
+
+use Psr\Container\ContainerInterface as Container;
+use Rollerworks\Component\Version\Version;
+
+return function (Container $container, Version $version, string $branch, ?string $releaseTitle, string $changelog) {
+    
+    $container->get('logger')->info('Updating composer branch-alias');
+    $container->get('process')->mustRun(['composer', 'config', 'extra.branch-alias.dev-'.$branch, sprintf('%d.%d-dev', $version->major, $version->minor)]);
+    
+    // Caution: Make sure to commit the changes. Hubkit will refuse to continue if there are dangling changes.
+    
+    /** @var \HubKit\Service\Git\GitBranch $gitBranch */
+    $gitBranch = $container->get('git.branch');
+    
+    if ($gitBranch->isWorkingTreeReady()) {
+        return; // Nothing to, composer is already up-to-date
+    }
+    
+    $gitBranch->add('composer.json');
+    $gitBranch->commit('Update composer branch-alias');
+    
+    /** @var \HubKit\Service\Git $git */
+    $git = $container->get('git.branch');
+    $git->pushToRemote('upstream', $branch);
+};
+```
+
+### Creating a pull request for the release (pre-release)
+
+**Caution:** This technique is not to be used as-is, understand the risk and be sure to apply enough
+error protections.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+// .hubkit/pre-release.php
+
+use Psr\Container\ContainerInterface as Container;
+use Rollerworks\Component\Version\Version;
+use Symfony\Component\Console\Helper\ProgressIndicator;
+
+return function (Container $container, Version $version, string $branch, ?string $releaseTitle, string $changelog) {
+    
+    /** @var \Psr\Log\LoggerInterface $logger */
+    $logger = $container->get('logger');
+    /** @var \HubKit\Service\GitHub $github */
+    $github = $container->get('github');
+    /** @var \HubKit\Service\Git\GitBranch $gitBranch */
+    $gitBranch = $container->get('git.branch');
+    
+    /** @var \Symfony\Component\Console\Style\SymfonyStyle $style */
+    $style = $container->get('style');
+    
+    $logger->info('Preparing new release branch');
+    $gitBranch->checkoutNew($releaseBranch = 'release-'.$version->full);
+    
+        $logger->info('Updating composer branch-alias');
+        $container->get('process')->mustRun(['composer', 'config', 'extra.branch-alias.dev-'.$branch, sprintf('%d.%d-dev', $version->major, $version->minor)]);
+         
+        // WARNING if nothing was changed this will crash the entire process, make sure to use something like:
+        // 
+        // if ($gitBranch->isWorkingTreeReady()) {
+        //     return;
+        // }
+        
+        $gitBranch->add('composer.json');
+        $gitBranch->commit('Update composer branch-alias');
+    
+    $gitBranch->pushToRemote('origin', $releaseBranch);
+    
+    $pr = $github->openPullRequest($branch, $releaseBranch, 'Release v'.$version->full, 'This might be a good place for a changelog.');
+    
+    $style->warning([
+        'Pull request '.$pr['html_url'].' was opened for this release.',
+        'The process will automatically continue once this pull request is merged.', 
+        '!! DO NOT ABORT THE COMMAND !!'
+    ]);
+    
+    $progress = new ProgressIndicator($style);
+    $progress->start('Waiting for pull request to be merged.');
+    
+    // Wait till the pull-request is merged. This might crash if the API limit is exceeded.
+    // 
+    // Alternatively you can merge the pull request directly, but make sure you use a proper CI.
+    while ($github->getPullRequest($pr['number'])['state'] === 'open') {
+        sleep(30); // sleep for 30 seconds
+        
+        $progress->advance();
+    }
+    
+    if ($github->getPullRequest($pr['number'])['merged'] === false) {
+        $progress->finish('Pull request was closed. Aborting.');
+        
+        exit(1);
+    }
+    
+    $progress->finish('Pull request was merged, continuing.');
+    $gitBranch->pullRemote('upstream', $branch);
+};
+```
+
+### Final words
+
+The `post-release` script might be used to automatically publish a blog post
+or reset the version information in a PHP file, to prepare for the next release.
+
+For more advanced usage in either the pre or post phase you might want to use something
+like https://github.com/liip/RMT#actions (be sure to set `vcs` to none to prevent conflicts).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -265,6 +265,13 @@ The `release` command has a number of special options:
 
 * `--title="A Bright New Year"`: Append a custom title to release name (after the version number);
 
+#### Release hooks
+
+The `release` command allows to executes a script prior (pre) and/or after (post) after the release
+operation. See [Release Hooks](release-hooks.md) for details.
+
+*Note:* You need at least Hubkit version 1.0.0-BETA18  
+
 #### Notes on signing
 
 The Git tag of a release is signed, *you can't disable this*. Make sure you have

--- a/src/Cli/HubKitApplicationConfig.php
+++ b/src/Cli/HubKitApplicationConfig.php
@@ -16,6 +16,7 @@ namespace HubKit\Cli;
 use HubKit\Container;
 use HubKit\Helper\BranchAliasResolver;
 use HubKit\Helper\SingleLineChoiceQuestionHelper;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Webmozart\Console\Adapter\ArgsInput;
 use Webmozart\Console\Adapter\IOOutput;
@@ -99,6 +100,7 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
                     $this->container['console_args'] = $args;
                     $this->container['sf.console_input'] = $input;
                     $this->container['sf.console_output'] = new IOOutput($io);
+                    $this->container['logger'] = new ConsoleLogger($this->container['sf.console_output']);
                 }
             }
         );
@@ -282,7 +284,8 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
                         $this->container['process'],
                         $this->container['editor'],
                         $this->container['config'],
-                        $this->container['splitsh_git']
+                        $this->container['splitsh_git'],
+                        $this->container['release_hooks']
                     );
                 })
             ->end()

--- a/src/Service/Git/GitBranch.php
+++ b/src/Service/Git/GitBranch.php
@@ -29,4 +29,19 @@ class GitBranch extends Git
     {
         $this->checkout($branch, true);
     }
+
+    public function add(string $file): void
+    {
+        $this->process->mustRun(['git', 'add', $file]);
+    }
+
+    public function commit(string $message): void
+    {
+        $this->process->mustRun(['git', 'commit', '-m', $message]);
+    }
+
+    public function commitAll(string $message): void
+    {
+        $this->process->mustRun(['git', 'commit', '-a', '-m', $message]);
+    }
 }

--- a/src/Service/ReleaseHooks.php
+++ b/src/Service/ReleaseHooks.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HubKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Service;
+
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Rollerworks\Component\Version\Version;
+
+class ReleaseHooks
+{
+    private $container;
+    private $git;
+    private $logger;
+
+    /**
+     * @var string|null
+     */
+    private $cwd;
+
+    public function __construct(ContainerInterface $container, Git $git, LoggerInterface $logger, ?string $cwd = null)
+    {
+        $this->logger = $logger;
+        $this->git = $git;
+        $this->container = $container;
+        $this->cwd = $cwd ?? getcwd();
+    }
+
+    public function preRelease(Version $version, string $branch, ?string $releaseTitle, string $changelog): ?string
+    {
+        return $this->executeScript('pre-release', $version, $branch, $releaseTitle, $changelog);
+    }
+
+    public function postRelease(Version $version, string $branch, ?string $releaseTitle, string $changelog): ?string
+    {
+        return $this->executeScript('post-release', $version, $branch, $releaseTitle, $changelog);
+    }
+
+    private function executeScript(string $type, Version $version, string $branch, ?string $releaseTitle, string $changelog): ?string
+    {
+        $scriptFile = $this->cwd.'/.hubkit/'.$type.'.php';
+
+        if (!file_exists($scriptFile)) {
+            $this->logger->debug('File {script} was not found. '.$type.' script will not be executed.', ['script' => $scriptFile]);
+
+            return '';
+        }
+
+        $hookCallback = include $scriptFile;
+
+        if (!\is_callable($hookCallback)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Expected script file "%s" to return a callable, got "%s" instead.',
+                    $scriptFile,
+                    \gettype($hookCallback)
+                )
+            );
+        }
+
+        $result = $hookCallback($this->container, $version, $branch, $releaseTitle, $changelog);
+
+        if (!$this->git->isWorkingTreeReady()) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Expected script file "%s" to leave a clean state after execution. Changed files must be committed by the script.',
+                    $scriptFile
+                )
+            );
+        }
+
+        return $result;
+    }
+}

--- a/tests/Handler/ReleaseHandlerTest.php
+++ b/tests/Handler/ReleaseHandlerTest.php
@@ -19,6 +19,7 @@ use HubKit\Service\CliProcess;
 use HubKit\Service\Editor;
 use HubKit\Service\Git;
 use HubKit\Service\GitHub;
+use HubKit\Service\ReleaseHooks;
 use HubKit\Service\SplitshGit;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument as PropArgument;
@@ -105,6 +106,8 @@ labels: removed-deprecation
     private $config;
     /** @var ObjectProphecy */
     private $splitshGit;
+    /** @var ObjectProphecy|ReleaseHooks */
+    private $releaseHooks;
     /** @var BufferedIO */
     private $io;
 
@@ -142,6 +145,8 @@ labels: removed-deprecation
 
         $this->splitshGit = $this->prophesize(SplitshGit::class);
         $this->splitshGit->checkPrecondition()->shouldNotBeCalled();
+
+        $this->releaseHooks = $this->prophesize(ReleaseHooks::class);
 
         $this->io = new BufferedIO();
         $this->io->setInteractive(true);
@@ -444,7 +449,8 @@ labels: removed-deprecation
             $this->process->reveal(),
             $this->editor->reveal(),
             $this->config,
-            $this->splitshGit->reveal()
+            $this->splitshGit->reveal(),
+            $this->releaseHooks->reveal()
         );
 
         $handler->handle($args, $this->io);

--- a/tests/Service/Fixtures/project-post-release/.hubkit/post-release.php
+++ b/tests/Service/Fixtures/project-post-release/.hubkit/post-release.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Psr\Container\ContainerInterface as Container;
+use Rollerworks\Component\Version\Version;
+
+return function (Container $container, Version $version, string $branch, ?string $releaseTitle, string $changelog) {
+    return 'executed-post';
+};

--- a/tests/Service/Fixtures/project-pre-post-release/.hubkit/post-release.php
+++ b/tests/Service/Fixtures/project-pre-post-release/.hubkit/post-release.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Psr\Container\ContainerInterface as Container;
+use Rollerworks\Component\Version\Version;
+
+return function (Container $container, Version $version, string $branch, ?string $releaseTitle, string $changelog) {
+    return 'executed-post';
+};

--- a/tests/Service/Fixtures/project-pre-post-release/.hubkit/pre-release.php
+++ b/tests/Service/Fixtures/project-pre-post-release/.hubkit/pre-release.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Psr\Container\ContainerInterface as Container;
+use Rollerworks\Component\Version\Version;
+
+return function (Container $container, Version $version, string $branch, ?string $releaseTitle, string $changelog) {
+    return 'executed-pre';
+};

--- a/tests/Service/Fixtures/project-pre-release/.hubkit/pre-release.php
+++ b/tests/Service/Fixtures/project-pre-release/.hubkit/pre-release.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Psr\Container\ContainerInterface as Container;
+use Rollerworks\Component\Version\Version;
+
+return function (Container $container, Version $version, string $branch, ?string $releaseTitle, string $changelog) {
+    return 'executed-pre';
+};

--- a/tests/Service/Fixtures/project-without-hooks/.gitkeep
+++ b/tests/Service/Fixtures/project-without-hooks/.gitkeep
@@ -1,0 +1,1 @@
+El Barto was not here.

--- a/tests/Service/ReleaseHooksTest.php
+++ b/tests/Service/ReleaseHooksTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HubKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Tests\Service;
+
+use HubKit\Service\Git;
+use HubKit\Service\ReleaseHooks;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Rollerworks\Component\Version\Version;
+
+final class ReleaseHooksTest extends TestCase
+{
+    /** @test */
+    public function it_does_nothing_when_there_are_hooks()
+    {
+        $gitProphecy = $this->prophesize(Git::class);
+        $gitProphecy->isWorkingTreeReady()->willReturn(true);
+        $git = $gitProphecy->reveal();
+
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+        $loggerProphecy->debug('File {script} was not found. pre-release script will not be executed.', Argument::any())->shouldBeCalled();
+        $loggerProphecy->debug('File {script} was not found. post-release script will not be executed.', Argument::any())->shouldBeCalled();
+        $logger = $loggerProphecy->reveal();
+
+        $hooks = new ReleaseHooks($this->createMock(ContainerInterface::class), $git, $logger, __DIR__.'/Fixtures/project-without-hooks');
+
+        $version = Version::fromString('1.0');
+
+        self::assertEmpty($hooks->preRelease($version, 'master', null, 'Something changed.'));
+        self::assertEmpty($hooks->postRelease($version, 'master', null, 'Something changed.'));
+    }
+
+    /** @test */
+    public function it_executes_pre_hook()
+    {
+        $gitProphecy = $this->prophesize(Git::class);
+        $gitProphecy->isWorkingTreeReady()->willReturn(true);
+        $git = $gitProphecy->reveal();
+
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+        $loggerProphecy->debug('File {script} was not found. pre-release script will not be executed.', Argument::any())->shouldNotBeCalled();
+        $loggerProphecy->debug('File {script} was not found. post-release script will not be executed.', Argument::any())->shouldBeCalled();
+        $logger = $loggerProphecy->reveal();
+
+        $hooks = new ReleaseHooks($this->createMock(ContainerInterface::class), $git, $logger, __DIR__.'/Fixtures/project-pre-release');
+
+        $version = Version::fromString('1.0');
+
+        self::assertEquals('executed-pre', $hooks->preRelease($version, 'master', null, 'Something changed.'));
+        self::assertEmpty($hooks->postRelease($version, 'master', null, 'Something changed.'));
+    }
+
+    /** @test */
+    public function it_executes_post_hook()
+    {
+        $gitProphecy = $this->prophesize(Git::class);
+        $gitProphecy->isWorkingTreeReady()->willReturn(true);
+        $git = $gitProphecy->reveal();
+
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+        $loggerProphecy->debug('File {script} was not found. pre-release script will not be executed.', Argument::any())->shouldBeCalled();
+        $loggerProphecy->debug('File {script} was not found. post-release script will not be executed.', Argument::any())->shouldNotBeCalled();
+        $logger = $loggerProphecy->reveal();
+
+        $hooks = new ReleaseHooks($this->createMock(ContainerInterface::class), $git, $logger, __DIR__.'/Fixtures/project-post-release');
+
+        $version = Version::fromString('1.0');
+
+        self::assertEmpty($hooks->preRelease($version, 'master', null, 'Something changed.'));
+        self::assertEquals('executed-post', $hooks->postRelease($version, 'master', null, 'Something changed.'));
+    }
+
+    /** @test */
+    public function it_executes_pre_post_hook()
+    {
+        $gitProphecy = $this->prophesize(Git::class);
+        $gitProphecy->isWorkingTreeReady()->willReturn(true);
+        $git = $gitProphecy->reveal();
+
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+        $loggerProphecy->debug('File {script} was not found. pre-release script will not be executed.', Argument::any())->shouldNotBeCalled();
+        $loggerProphecy->debug('File {script} was not found. post-release script will not be executed.', Argument::any())->shouldNotBeCalled();
+        $logger = $loggerProphecy->reveal();
+
+        $hooks = new ReleaseHooks($this->createMock(ContainerInterface::class), $git, $logger, __DIR__.'/Fixtures/project-pre-post-release');
+
+        $version = Version::fromString('1.0');
+
+        self::assertEquals('executed-pre', $hooks->preRelease($version, 'master', null, 'Something changed.'));
+        self::assertEquals('executed-post', $hooks->postRelease($version, 'master', null, 'Something changed.'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #9 
| License       | MIT

This finally adds support for executing scripts prior and/or after the `release` command. Most of the actual logic (including error handling) must be handled by the custom script itself, but putting this in Hubkit would make things to complicated (for now) and I like the way this gives enough control of the operation.