### PR TITLE
Rewrite documentation for better readability

### DIFF
--- a/docs/commands/branch-alias.md
+++ b/docs/commands/branch-alias.md
@@ -1,0 +1,16 @@
+branch-alias
+============
+
+Set/get the "master" branch-alias. Omit the `alias` argument to get the current alias.
+
+To set a branch-alias for the "master" branch use:
+
+```bash
+$ hubkit branch-alias 1.0
+```
+
+To get the branch-alias for the "master" branch use the command without any arguments:
+
+```bash
+$ hubkit branch-alias
+```

--- a/docs/commands/changelog.md
+++ b/docs/commands/changelog.md
@@ -1,0 +1,84 @@
+changelog
+=========
+
+Generate a changelog, formatted according to http://keepachangelog.com/
+with all detectable changes between releases (the specified) commits.
+
+**Caution:**
+
+> The changelog auto formatting works because of some conventions used in HubKit.
+>
+> Only pull requests that were merged with the [merge](merge.md) command (not the merge button!)
+> will be properly categorized and labeled, all others show-up in he "Changed" section.
+
+The commit range is automatically determined using the last tag on the (current)
+branch and the current branch. Eg. `v1.0.0..master`. But you can provide your 
+own range as you would with `git log`, except now you get a nice changelog!
+
+```bash
+$ hubkit v1.0.0..master
+```
+
+Will produce something like:
+
+```markdown
+### Added
+- Introduce a new API for ValuesBag ([sstok](https://github.com/sstok)) [#93](https://github.com/park-manager/hubkit/issues/93)
+
+### Changed
+- Clean up ([sstok](https://github.com/sstok)) [#56](https://github.com/park-manager/hubkit/issues/56)
+
+### Deprecated
+- Great new architecture ([sstok](https://github.com/sstok), [someone](https://github.com/someone)) [#55](https://github.com/park-manager/hubkit/issues/55)
+
+### Removed
+- [BC BREAK] Removed deprecated API ([sstok](https://github.com/sstok)) [#52](https://github.com/park-manager/hubkit/issues/52)
+```
+
+To prevent the changelog from being to cluttered empty sections are left out,
+but if you prefer you can include these empty sections using the `--all` option.
+
+```markdown
+### Security
+- nothing
+
+### Added
+- Introduce a new API for ValuesBag ([sstok](https://github.com/sstok)) [#93](https://github.com/park-manager/hubkit/issues/93)
+
+### Changed
+- Clean up ([sstok](https://github.com/sstok)) [#56](https://github.com/park-manager/hubkit/issues/56)
+
+### Deprecated
+- Great new architecture ([sstok](https://github.com/sstok), [someone](https://github.com/someone)) [#55](https://github.com/park-manager/hubkit/issues/55)
+
+### Removed
+- [BC BREAK] Removed deprecated API ([sstok](https://github.com/sstok)) [#52](https://github.com/park-manager/hubkit/issues/52)
+
+### Fixed
+- nothing
+```
+
+**Note:** Security is placed higher then the original spec to ensure they are noticed.
+
+## Single line formatting
+
+Alternatively you can use the `--online` option to get a changelog without sections.
+
+```markdown
+- Introduce a new API for ValuesBag ([sstok](https://github.com/sstok)) [#93](https://github.com/park-manager/hubkit/issues/93)
+- Clean up ([sstok](https://github.com/sstok)) [#56](https://github.com/park-manager/hubkit/issues/56)
+- Great new architecture ([sstok](https://github.com/sstok), [someone](https://github.com/someone)) [#55](https://github.com/park-manager/hubkit/issues/55)
+- [BC BREAK] Removed deprecated API ([sstok](https://github.com/sstok)) [#52](https://github.com/park-manager/hubkit/issues/52)
+```
+
+### Labeling detection
+
+HubKit automatically uses the following labels (case insensitive) for special conventions, 
+like detecting breaking changes and deprecations:
+
+* `deprecation` puts the change in the `Deprecated` section
+* `deprecation removal` puts the change in the `Removed` section
+* `bc break` marks the change with `[BC BREAK]`
+
+Lastly all merge commits (for pull requests) use the `category #number title (author-id)` convention
+like `feature #68 [Release] add support for pre/post scripts (sstok)`.

--- a/docs/commands/checkout.md
+++ b/docs/commands/checkout.md
@@ -1,0 +1,16 @@
+checkout
+========
+
+Checkout a pull request by number. This creates a new branch based on the user
+and branch name to prevent conflicts with your local branches, eg. `sstok--great-new-feature`.
+
+```
+hubkit checkout 123
+```
+
+**Note:** If the branch already exists it's updated instead.
+
+Unless the author of the pull request disabled this feature, it's possible to push new changes
+to the user's fork by simply using either `git push author-name`.
+
+_HubKit already configures the upstream for your, but remember to be careful with forced pushes._

--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -1,0 +1,41 @@
+merge
+=====
+
+Merge a pull request with preservation of the original title/description and comments.
+Plus some additional information for the [changelog](changelog.md) command.
+
+To merge pull request `#22` in your repository simple run:
+
+```bash
+$ hubkit merge 22
+```
+
+And choose a category (feature, refactor, bug, minor, style, security).
+
+**Note:** You may get a warning that some checks are pending, depending on your
+repository's branch protection you may not be able to merge then.
+
+Once the pull request is merged your local branch (if existent) is automatically
+updated. Use the `--no-pull` option to skip pulling changes to your local base branch.
+
+## Bat on the back
+
+Once the pull request is merged the author (unless you are merging your own)
+automatically gets little "pat on the back" for there work.
+
+You can change the (default) message `Thank you @author` using the `--pat` option.
+
+```bash
+$ hubkit merge 22 --pat=':beers: @author !'
+```
+
+Or use the `--no-pat` option to skip it for this merge.
+
+**Caution:** The `!` has a special meaning in the shell, use single quotes
+to prevent expansion.
+
+## Squash
+
+Use the `--squash` option to squash the pull request before merging.
+
+

--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -1,0 +1,51 @@
+release
+=======
+
+Make a new release for the current branch. This creates a signed Git tag and GitHub release-page.
+
+The `release` command automatically generates a changelog and allows to add
+additional info using your favorite editor. Use `--no-edit` to skip the editing,
+you can change the content later using the GitHub web interface.
+
+```bash
+$ hubkit release 1.0.0
+```
+
+A version is expected to follow the SemVer format, eg. `v1.0.0`, `0.1.0` or `v1.0.0-BETA1`.
+The leading `v` is automatically added when missing and the meta version (alpha, beta, rc) is
+upper cased.
+
+**Tip:**
+
+> The version is automatically expended, so `1.0` is expended to `1.0.0`.
+>
+> And versions are validated against gaps, so you can't make a mistake.
+
+## Special options
+
+The `release` command has a number of special options:
+
+* `--all-categories`: Show all categories (including empty) (same as `--all` of the [changelog](changelog.md) command);
+
+* `--no-edit`: Don't open the editor for editing the release page, accept the changelog as-is;
+
+* `--pre-release`: Mark the release as a pre-release (not production ready);
+
+* `--title="A Bright New Year"`: Append a custom title to release name (after the version number);
+
+## Release hooks
+
+The `release` command allows to executes a script prior (pre) and/or after (post) after the release
+operation. See [Release Hooks](release-hooks.md) for details.
+
+*Note:* You need at least HubKit version 1.0.0-BETA18 to use release hooks.
+
+## Notes on Git tag signing
+
+The Git tag of each release is cryptographically signed, **this cannot be disabled**.
+Make sure you have a signing key configured, and that your gpg/pgp application is 
+set-up properly.
+
+Run `hubkit self-diagnose` to test if this set-up correctly for you.
+
+See also: https://git-scm.com/book/tr/v2/Git-Tools-Signing-Your-Work

--- a/docs/commands/repo-create.md
+++ b/docs/commands/repo-create.md
@@ -1,0 +1,20 @@
+repo-create
+===========
+
+Create a new minimal empty GitHub repository. Wiki and Downloads are disabled by default.
+
+```bash
+$ hubkit repo-create park-manager/hubkit
+```
+
+This creates the "hubkit" repository in the "park-manager" organization. To create a 
+private repository (may require a paid plan) use the `--private` option.
+
+# Special options
+
+The `repo-create` command has a number of special options:
+
+* `--private`: Create private repository (may require a paid plan);
+
+* `--no-issues`: Disable issues, usable when you have a global issue tracker or using
+  a third party solution like Jira.

--- a/docs/commands/upmerge.md
+++ b/docs/commands/upmerge.md
@@ -1,0 +1,46 @@
+upmerge
+=======
+
+Merge the current branch to the next possible version branch (either merge 1.0 into 1.1).
+
+**Caution:** Split repositories are (currently) [not automatically updated](https://github.com/park-manager/hubkit/issues/61) after an upmerge operation.
+
+Some projects follow a 'merge bug fixes to the lowest supported branch first' approach,
+and then (up)merge the lower branches into newer branches. Usually: `1.0 -> 2.0 -> master`.
+
+But this process is tedious (boring) and error prone, the `upmerge` command makes
+this boring work, as simple and save as possible.
+
+The process ensures your local source *and* target branch are up-to-date, with
+the recommended flags (`--no-ff` and `--log`), and pushes to upstream.
+
+To use this command first checkout the lowest supported branch, either `1.0`. 
+And run the upmerge command.
+
+```bash
+$ git checkout 1.0
+$ hubkit upmerge
+```
+
+That's it! The command automatically detects which branch `1.0` is to be merged into.
+
+**Caution:** The `upmerge` command uses the Semantic Versioning schematics, versions
+are automatically detected based on there precedence. **Don't use this command when
+you use GitFlow!**
+
+Need to merge more then one branch? Use `--all` option to merge the current branch
+into the "next preceded version" branch, and that one into the it's next, and finally
+then into the "master" branch.
+
+```bash
+$ git checkout 1.0
+$ hubkit upmerge --all
+```
+
+## Conflict resolving
+
+By merging branches into each other, you might cause some merge conflicts.
+
+When this happens you can simple resolve the conflicts as you would with using 
+the `git mergetool`, then once all conflicts are resolved. Run the `upmerge` 
+command again and it will continue as normal.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,8 @@ Composer is assumed to be installed and configured in your PATH.
 HubKit is a PHP application, you don't install it as a dependency
 and you don't you install it with Composer global.
 
+> Currently there is no Phar version available, this is being worked-on.
+
 To install HubKit first choose a directory where you want to keep the installation.
 Eg. `~/.hubkit` or any of your choice.
 

--- a/docs/release-hooks.md
+++ b/docs/release-hooks.md
@@ -8,7 +8,7 @@ But sometimes you need to perform a special operation before and/or after the re
 This might vary from updating the `composer.json` branch-alias, to creating a pull request for 
 the new release.
 
-Now instead of doing this manually Hubkit allows to hook-into the release process, but executing
+Now instead of doing this manually HubKit allows to hook-into the release process, but executing
 a custom script before and/or after a new release created.
 
 Both the pre and post hooks work the same way, but are executed at different stages.
@@ -31,7 +31,7 @@ use Rollerworks\Component\Version\Version;
 return function (Container $container, Version $version, string $branch, ?string $releaseTitle, string $changelog) {
     // Place the hooks logic here.
     
-    // The $container provides access to the Hubkit application Service Container
+    // The $container provides access to the HubKit application Service Container
     // with among following services: github, git (git.config, git.branch), process, filesystem, style, editor, logger.
     // 
     // See \HubKit\Container for all services and there corresponding classes.
@@ -60,7 +60,7 @@ return function (Container $container, Version $version, string $branch, ?string
     $container->get('logger')->info('Updating composer branch-alias');
     $container->get('process')->mustRun(['composer', 'config', 'extra.branch-alias.dev-'.$branch, sprintf('%d.%d-dev', $version->major, $version->minor)]);
     
-    // Caution: Make sure to commit the changes. Hubkit will refuse to continue if there are dangling changes.
+    // Caution: Make sure to commit the changes. HubKit will refuse to continue if there are dangling changes.
     
     /** @var \HubKit\Service\Git\GitBranch $gitBranch */
     $gitBranch = $container->get('git.branch');
@@ -91,7 +91,7 @@ return function (Container $container, Version $version, string $branch, ?string
     $container->get('logger')->info('Updating composer branch-alias');
     $container->get('process')->mustRun(['composer', 'config', 'extra.branch-alias.dev-'.$branch, sprintf('%d.%d-dev', $version->major, $version->minor)]);
     
-    // Caution: Make sure to commit the changes. Hubkit will refuse to continue if there are dangling changes.
+    // Caution: Make sure to commit the changes. HubKit will refuse to continue if there are dangling changes.
     
     /** @var \HubKit\Service\Git\GitBranch $gitBranch */
     $gitBranch = $container->get('git.branch');

--- a/docs/split-repositories.md
+++ b/docs/split-repositories.md
@@ -1,0 +1,102 @@
+Managing Split Repositories
+===========================
+
+A special feature of HubKit is the ability to handle monolith project developments,
+instead of having separate Git repositories for each package all are housed in a 
+central repository from where all work is coordinated.
+
+**Before you continue make sure [splitsh-lite](https://github.com/splitsh/lite) is 
+installed and can be found in your `PATH` environment (no `alias`!).**
+
+### Configuration
+
+To make this "repository splitting" work, a number of targets must 
+be configured. Each target consists of a prefix (directory path),
+target repository and some additional options like if tag-synchronizing is enabled.
+
+**Suffice to say the repositories must exist! They are not automatically created,
+use the [create-repo](commands/create-repro.md) command with the correct arguments
+to create the repositories.**
+
+In your global `config.php` set the following:
+
+```php
+    ...
+
+    // Configuration for repository splitting.
+    // Structure is expected to be: [hostname][organization/source-repository]
+    // With 'split' being a list of paths (relative to repository root, and no patterns)
+    //    and the value e.g. an 'push url' or `['url' => 'push url', 'sync-tags' => false]`.
+    //
+    // All configured targets are split when requested. Missing directories are ignored.
+    //
+    // The push remote is automatically registered.
+    // The 'sync-tags' can be configured for all split targets, and per target.
+    //
+    'repos' => [
+        'github.com' => [
+            'park-manager/park-manager' => [
+                'sync-tags' => true,
+                'split' => [
+                    'src/Bundle/CoreBundle' => 'git@github.com:park-manager/core-bundle.git',
+                    'src/Bundle/TestBundle' => 'git@github.com:park-manager/test-bundle.git',
+                    'src/Bundle/UserBundle' => 'git@github.com:park-manager/user-bundle.git',
+                    'src/Component/Core' => 'git@github.com:park-manager/core.git',
+                    'src/Component/Model' => 'git@github.com:park-manager/model.git',
+                    'src/Component/Security' => 'git@github.com:park-manager/security.git',
+                    'src/Component/User' => 'git@github.com:park-manager/user.git',
+                    'src/Component/WebUI' => 'git@github.com:park-manager/webui.git',
+                    'src/Module/Webhosting' => 'git@github.com:park-manager/webhosting.git',
+                    'src/Bridge/Doctrine' => 'git@github.com:park-manager/doctrine-bridge.git',
+                ],
+            ],
+        ],
+    ],
+```
+
+*And don't forget to change the values to suite your own.*
+
+To test if the configuration is correct run `hubkit split-repo --dry-run`
+to see what would have happened.
+
+Everything correct? Then run `hubkit split-repo` (this may take some time).
+
+**Tip:** Managing the configuration of split-repositories is tedious work, in HubKit v2.0
+this will be made much more developer friendly.
+
+## Splitting during merge/release
+
+Once the repository splitting is configured, you want to make sure the split repositories 
+are up-to-date.
+
+After a [pull request is merged](merge.md) you are automatically asked if you want 
+to split the monolith repository, this process may take some time depending of number 
+of commits and targets. 
+
+If you need to merge more then one pull-request you properly want to hold-of
+the split operation till you're done. 
+
+**Caution:** Splitting is automatically skipped when the `--no-pull` option is provided.
+
+The release command works a little different here, when making a new release the 
+split operation is always performed! You cannot skip this. However you can skip
+the synchronizing of tags to certain split repositories by setting the `sync-tags` 
+config to false.
+
+```php
+    ...
+
+    'repos' => [
+        'github.com' => [
+            'park-manager/park-manager' => [
+                'sync-tags' => false, // disable for all (or)
+                'split' => [
+                    // Disable/enable per repository target
+                    'src/Bundle/CoreBundle' => ['url' => 'git@github.com:park-manager/core-bundle.git', 'sync-tags' => true],
+                ],
+            ],                
+        ],
+    ],
+```
+
+Existing tags in split repositories are always ignored. 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,10 +7,10 @@ HubKit works by a number of conventions which cannot be changed, the configurati
 mainly contains your authentication credentials and some personal preferences.
 
 Assuming you already copied `config.php.dist` to `config.php`. Open `config.php`
-and fill-in in your authentication credentials.
+and fill-in your authentication credentials.
 
-Whenever you changed the configuration it's advised to run `hubkit self-diagnose`
-to check if everything is configured properly.
+**Tip:** Whenever you change the configuration it's advised to run `hubkit self-diagnose`
+afterwards to check if everything is configured properly.
 
 ### Working with GitHub Enterprise
 
@@ -44,7 +44,7 @@ return [
 ];
 ```
 
-Say you have an GitHub Enterprise on `development.example.com`, first add the development.example.com
+Say you have an GitHub Enterprise on `development.example.com`, first add the `development.example.com`
 hub configuration to your `config.php` file:
 
 ```phph
@@ -81,13 +81,29 @@ to test if everything is working.
 Whenever you use hubkit in a Git repository it will automatically detect the
 correct hub configuration by remote "upstream".
 
+## Self Diagnoses
+
+The `self-diagnose` checks your system is ready to use HubKit and gives recommendations 
+about changes you should make.
+
+**Note:** It's recommended to run this command from a local Git repository,
+as more information is shown then.
+
+## Repository splitting
+
+A special feature of HubKit is the ability to manage split monolith repositories,
+each split-repository holds the contents of a smaller portion of the main monolith 
+repository.
+
+See [Managing Split Repositories](split-repositories.md) for all details.
+
 ## Commands
 
 Run `hubkit help` for a full list of all available commands and options.
 
 **Note:** All commands except `help`, `repo-create` and `self-diagnose` require
 you are in a Git repository, and have Git remote `upstream` existing and pointing
-to the GitHub head repository (from which all work is coordinated, not your fork).
+to the GitHub main repository (from which all work is coordinated, not your fork).
 
 For the `repo-create` command you may need to provide which hub configuration you
 want to use. By default 'github.com' is used, use `--host=development.example.com`
@@ -95,225 +111,20 @@ for the Enterprise example shown above.
 
 Command names and options are in lowercase.
 
-### branch-alias
-
-Set/get the "master" branch-alias. Omit the `alias` argument to get the current alias.
-
-To set a branch-alias for the "master" use:
-
-```bash
-$ hubkit branch-alias 1.0
-```
-
-To get the branch-alias for "master" use the command without any arguments:
-
-```bash
-$ hubkit branch-alias
-```
-
-### changelog
-
-Generate a changelog, formatted according to http://keepachangelog.com/
-with all changes between (the specified) commits.
-
-**Note:** Security is placed higher then the original spec to ensure they
-are noticed.
-
-The commit range is automatically determined using the last tag on the (current)
-branch and the current branch. Eg. `v1.0.0..master`. But you can provide your own range
-as you would with `git log`, except now you get a nice changelog!
-
-```bash
-$ hubkit v1.0.0..master
-```
-
-Will produce something like:
-
-```markdown
-### Added
-- Introduce a new API for ValuesBag ([sstok](https://github.com/sstok)) [#93](https://github.com/park-manager/hubkit/issues/93)
-
-### Changed
-- Clean up ([sstok](https://github.com/sstok)) [#56](https://github.com/park-manager/hubkit/issues/56)
-
-### Deprecated
-- Great new architecture ([sstok](https://github.com/sstok), [someone](https://github.com/someone)) [#55](https://github.com/park-manager/hubkit/issues/55)
-
-### Removed
-- [BC BREAK] Removed deprecated API ([sstok](https://github.com/sstok)) [#52](https://github.com/park-manager/hubkit/issues/52)
-```
-
-To prevent the changelog from being to cluttered empty sections are left out,
-but if you prefer you can include these using the `--all` option.
-
-```markdown
-### Security
-- nothing
-
-### Added
-- Introduce a new API for ValuesBag ([sstok](https://github.com/sstok)) [#93](https://github.com/park-manager/hubkit/issues/93)
-
-### Changed
-- Clean up ([sstok](https://github.com/sstok)) [#56](https://github.com/park-manager/hubkit/issues/56)
-
-### Deprecated
-- Great new architecture ([sstok](https://github.com/sstok), [someone](https://github.com/someone)) [#55](https://github.com/park-manager/hubkit/issues/55)
-
-### Removed
-- [BC BREAK] Removed deprecated API ([sstok](https://github.com/sstok)) [#52](https://github.com/park-manager/hubkit/issues/52)
-
-### Fixed
-- nothing
-```
-
-Alternatively you use the `--online` option to get a changelog without sections.
-
-```markdown
-- Introduce a new API for ValuesBag ([sstok](https://github.com/sstok)) [#93](https://github.com/park-manager/hubkit/issues/93)
-- Clean up ([sstok](https://github.com/sstok)) [#56](https://github.com/park-manager/hubkit/issues/56)
-- Great new architecture ([sstok](https://github.com/sstok), [someone](https://github.com/someone)) [#55](https://github.com/park-manager/hubkit/issues/55)
-- [BC BREAK] Removed deprecated API ([sstok](https://github.com/sstok)) [#52](https://github.com/park-manager/hubkit/issues/52)
-```
-
-**Caution:** The changelog auto formatting works because of some conventions used
-in HubKit. Only pull requests that were merged with the `merge` command (not the merge button!)
-will be properly categorized and labeled, all others show-up in he "Changed" section.
-
-### checkout
-
-Checkout a pull request by number. This creates a new branch based on the user
-and branch name to prevent conflicts with your local branches, eg. `sstok--great-new-feature`.
-If the branch already exists it's updated instead.
-
-Unless the author of the pull request disabled this feature. It's possible to push new changes
-to user's fork by simply using `git push`. _HubKit already configured the upstream for your,
-but remember to be careful with forced pushes._
-
-### merge
-
-Merge a pull request with preservation of the original title/description and comments.
-Plus some additional information for the `changelog` command.
-
-To merge pull request `#22` in your repository simple run:
-
-```bash
-$ hubkit merge 22
-```
-
-And choose a category (feature, refactor, bug, minor, style).
-
-**Note:** You may get a warning that some checks are pending, depending on your
-repository's branch protection you may not be able to merge then.
-
-#### Bat on the back
-
-Once the pull request is merged the author (unless you are merging your own)
-automatically gets little "pat on the back" for there work.
-
-You can change the (default) message `Thank you @author` using the `--pat` option.
-
-```bash
-$ hubkit merge 22 --pat=':beers: @author !'
-```
-
-Or use the `--no-pat` option to skip it for this merge.
-
-**Caution:** The `!` has a special meaning in the shell, use single quotes
-to prevent expansion.
-
-#### Special options
-
-The `merge` command has a number of special options:
-
-* `--squash`: Squash the pull request before merging;
-
-* `--no-pull`: Skip pulling changes to your local base branch;
-
-* `--security`: Merge pull request as a security patch (uses the 'security' category);
-
-### release
-
-Make a new release for the current branch, this creates a signed Git tag and GitHub release-page.
-
-The `release` command automatically generates a changelog and allows to add
-additional info using your favorite editor. Use `--no-edit` to skip the editing,
-you can change the content later using the GitHub web interface.
-
-```bash
-$ hubkit release 1.0.0
-```
-
-A version is expected to follow the SemVer format, eg. `v1.0.0`, `0.1.0` or `v1.0.0-BETA1`.
-Leading `v` is automatically added when missing and the meta version (alpha, beta, rc) is
-upper cased.
-
-**Tip:**
-
-> The version is automatically expended, so `1.0` is expended to `1.0.0`.
->
-> And versions are validated against gaps, so you can't make a mistake.
-
-#### Special options
-
-The `release` command has a number of special options:
-
-* `--all-categories`: Show all categories (including empty) (same as `--all` of the `changelog` command);
-
-* `--no-edit`: Don't open the editor for editing the release page, accept the changelog as-is;
-
-* `--pre-release`: Mark as pre-release (not production ready);
-
-* `--title="A Bright New Year"`: Append a custom title to release name (after the version number);
-
-#### Release hooks
-
-The `release` command allows to executes a script prior (pre) and/or after (post) after the release
-operation. See [Release Hooks](release-hooks.md) for details.
-
-*Note:* You need at least Hubkit version 1.0.0-BETA18  
-
-#### Notes on signing
-
-The Git tag of a release is signed, *you can't disable this*. Make sure you have
-a signing key configured and that gpg/pgp is set-up properly.
-
-See also: https://git-scm.com/book/tr/v2/Git-Tools-Signing-Your-Work
-
-### repo-create (deprecated)
-
-Creates a new minimal empty GitHub repository.
-Wiki and Downloads are disabled by default.
-
-```bash
-$ hubkit repo-create park-manager/hubkit
-```
-
-This creates the "hubkit" repository in the "park-manager" organization.
-To create a private repository (may require a paid plan) use the `--private` option.
-
-**Note:** This command is considered deprecated, it will not be removed
-anytime soon, but will be moved to RepoKit (not publicly available yet).
-
-#### Special options
-
-The `repo-create` command has a number of special options:
-
-* `--private`: Create private repository (may require a paid plan);
-
-* `--no-issues`: Disable issues, usable when you have a global issue tracker or using
-  a third party solution like Jira.
-
-### self-diagnose
-
-Checks your system is ready to use HubKit and gives recommendations
-about changes you should make.
-
-**Note:** It's recommended to run this command from a local Git repository,
-as more information is shown then.
+* [branch-alias](branch-alias.md)
+* [changelog](changelog.md)
+* [checkout](checkout.md)
+* [merge](merge.md)
+* [release](release.md)
+* [repo-create](repo-create.md)
+* [upmerge](upmerge.md)
+
+Further there are some minor commands to help you in your daily operation
+as a maintainer.
 
 ### take
 
-Take an issue (no pull request) to work on, checkout the issue as new branch.
+Take an issue (no pull request) to work on. In practice this checkouts the issue as new branch.
 
 ```bash
 $ hubkit take 22
@@ -322,9 +133,13 @@ $ hubkit take 22
 By default the "master" branch is used as base, use the `--base` option to use
 a different one. Eg. `--base=1.x` for `upstream/1.x`.
 
+```bash
+$ hubkit take --base=1.x 22
+```
+
 ### switch-base
 
-Switch the base of a pull request (and perform a rebase to prevent unwanted commits).
+Switch the base of a pull request (and performs a rebase to prevent unwanted commits).
 
 ```bash
 $ hubkit switch-base 22 1.6
@@ -339,136 +154,3 @@ then once all conflicts are resolved. Run the `switch-base` command (with the or
 again and it will continue as normal.
 
 **Do not push these changes manually as this will not update the pull-request target base.**
-
-### upmerge
-
-Merge the current branch to the next version branch (eg. 1.0 into 1.1).
-
-Most projects follow a 'merge bug fixes to the lowest supported branch first' approach,
-and then merge the lower branch into newer branches. Usually: `1.0 -> 2.0 -> master`.
-
-But this process is tedious (boring) and error prone, the `upmerge` command makes
-this boring work, as simple and save as possible.
-
-The process ensures your local source *and* target branch are up-to-date,
-uses the correct flags (`--no-ff` and `--log`), and pushes to upstream.
-
-First checkout the lowest supported branch, eg. `1.0`. And run the upmerge command.
-
-```bash
-$ git checkout 1.0
-$ hubkit upmerge
-```
-
-That's it! The command automatically detects which branch `1.0` is to be merged into.
-
-**Caution:** The `upmerge` command uses the Semantic Versioning schematics, versions
-are automatically detected based on there precedence. **Don't use this command when
-you use GitFlow!**
-
-Need to merge more then one branch? Use `--all` option to merge the current branch
-into the "next preceded version" branch, and that one into the it's next, and finally
-them master branch.
-
-#### Conflict resolving
-
-Mering branches into each other you cause some merge conflicts.
-
-When this happens you can simple resolve the conflicts as you would with using `git merge`,
-then once all conflicts are resolved. Run the `upmerge` command again and it will
-continue as normal.
-
-## split-repo
-
-Splits the repository into other repositories.
-
-This operation is related to monolith project development, instead of having separate 
-Git repositories for each package all are housed in a central repository from where 
-all work is coordinated.
-
-To make distribution of the packages possible they are split into "push only" repositories 
-(no issues or pull requests).
-
-**Warning:** Repository splitting only works when using HubKit, using the GitHub merge button 
-does not automatically split the repository!
-
-**Before you continue make sure [splitsh-lite](https://github.com/splitsh/lite) is 
-installed and can be found in your path (no `alias`!).** 
-
-Run `hubkit self-diagnose` to check your configuration.
-
-### Configuration
-
-To make this "repository splitting" work, a number of targets must 
-be configured. Each target consists of a prefix (directory path),
-target repository and optionally if tag-synchronizing is enabled.
-
-**Suffice to say the repositories must exist! They are not automatically created,
-use the `create-repo` command with the correct arguments to create the repositories.**
-
-In your global `config.php` set the following:
-
-```php
-    ...
-
-    // Configuration for repository splitting.
-    // Structure is expected to be: [hostname][organization/source-repository]
-    // With 'split' being a list of paths (relative to repository root, and no patterns)
-    //    and the value e.g. an 'push url' or `['url' => 'push url', 'sync-tags' => false]`.
-    //
-    // All configured targets are split when requested. Missing directories are ignored.
-    //
-    // The push remote is automatically registered.
-    // The 'sync-tags' can be configured for all split targets, and per target.
-    //
-    'repos' => [
-        'github.com' => [
-            'park-manager/park-manager' => [
-                'sync-tags' => true,
-                'split' => [
-                    'src/Bundle/CoreBundle' => 'git@github.com:park-manager/core-bundle.git',
-                    'src/Bundle/TestBundle' => 'git@github.com:park-manager/test-bundle.git',
-                    'src/Bundle/UserBundle' => 'git@github.com:park-manager/user-bundle.git',
-                    'src/Component/Core' => 'git@github.com:park-manager/core.git',
-                    'src/Component/Model' => 'git@github.com:park-manager/model.git',
-                    'src/Component/Security' => 'git@github.com:park-manager/security.git',
-                    'src/Component/User' => 'git@github.com:park-manager/user.git',
-                    'src/Component/WebUI' => 'git@github.com:park-manager/webui.git',
-                    'src/Module/Webhosting' => 'git@github.com:park-manager/webhosting.git',
-                    'src/Bridge/Doctrine' => 'git@github.com:park-manager/doctrine-bridge.git',
-                ],
-            ],
-        ],
-    ],
-```
-
-*And obviously change the values to suite your own.*
-
-> Park-Manager core developers should contact the project lead for
-> the correct configuration to use for `park-manager/park-manager`.
-
-To test if the configuration is correct run `hubkit split-repo --dry-run`
-to see what would have happened.
-
-Everything correct? Then run `hubkit split-repo` (this may take some time).
-
-### Splitting during merge/release
-
-Once the repository splitting is configured, you want to make sure
-the split repositories are up-to-date.
-
-When running `merge` you are automatically asked if you want to split now,
-this process may take some time depending of number of commits and targets.
-
-**Note:** If you need to merge more then one pull-request you properly want to hold-of
-the split operation till you're done. Changes never split when the `--no-pull` option
-is provided.
-
-The release command works a little different here, when making a new release the 
-split operation is always performed! You cannot skip this. However you can skip
-the synchronizing of tags to certain split repositories.
-
-**Note:** The split operation is performed first, then split repositories
-are tagged, and *then* the main repository is tagged. This ensures when something
-goes wrong the main repository remains unaffected, existing tags in split repositories
-are simple ignored. 


### PR DESCRIPTION
Commands are now separated into separate pages, and the repository splitting is beter explained.
