### PR TITLE
[Upmerge] Automatically split repositories

### DIFF
--- a/src/Cli/HubKitApplicationConfig.php
+++ b/src/Cli/HubKitApplicationConfig.php
@@ -259,12 +259,15 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
                 ->addArgument('branch', Argument::OPTIONAL | Argument::STRING, 'Base branch to checkout and start with, uses current when omitted')
                 ->addOption('all', null, Option::NO_VALUE | Option::BOOLEAN, 'Merge all version branches from lowest into highest (and finally master)')
                 ->addOption('dry-run', null, Option::NO_VALUE | Option::BOOLEAN, 'Show which operations would have been performed (without actually merging)')
+                ->addOption('no-split', null, Option::NO_VALUE | Option::BOOLEAN, 'Skip splitting of repositories (when they are configured)')
                 ->setHandler(function () {
                     return new Handler\UpMergeHandler(
                         $this->container['style'],
                         $this->container['git'],
                         $this->container['github'],
-                        $this->container['process']
+                        $this->container['process'],
+                        $this->container['config'],
+                        $this->container['splitsh_git']
                     );
                 })
             ->end()

--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -250,6 +250,11 @@ class Git
         }
     }
 
+    public function deleteBranchWithForce(string $name)
+    {
+        $this->process->run(['git', 'branch', '-D', $name], sprintf('Could not delete branch "%s".', $name));
+    }
+
     public function addNotes(string $notes, string $commitHash, string $ref = 'github-comments')
     {
         $tmpName = $this->filesystem->newTempFilename();

--- a/tests/Handler/UpMergeHandlerTest.php
+++ b/tests/Handler/UpMergeHandlerTest.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace HubKit\Tests\Handler;
 
 use HubKit\Cli\Handler\UpMergeHandler;
+use HubKit\Config;
 use HubKit\Service\CliProcess;
 use HubKit\Service\Git;
 use HubKit\Service\GitHub;
+use HubKit\Service\SplitshGit;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Webmozart\Console\Api\Args\Args;
@@ -35,6 +37,16 @@ class UpMergeHandlerTest extends TestCase
     /** @var ObjectProphecy */
     private $github;
 
+    /**
+     * @var SplitshGit|ObjectProphecy
+     */
+    private $splitshGit;
+
+    /**
+     * @var Config
+     */
+    private $config;
+
     /** @before */
     public function setUpCommandHandler()
     {
@@ -47,6 +59,19 @@ class UpMergeHandlerTest extends TestCase
         $this->github->getRepository()->willReturn('hubkit');
 
         $this->process = $this->prophesize(CliProcess::class);
+
+        $this->expectConfigHasSplits();
+
+        $this->config = new Config([
+            'repos' => [
+                'github.com' => [
+                    'park-manager/park-manager' => [],
+                ],
+            ],
+        ]);
+
+        $this->splitshGit = $this->prophesize(SplitshGit::class);
+        $this->splitshGit->checkPrecondition()->shouldNotBeCalled();
     }
 
     /** @test */
@@ -66,6 +91,57 @@ class UpMergeHandlerTest extends TestCase
         $this->git->pushToRemote('upstream', ['2.5'], true)->shouldBeCalled();
 
         $this->executeHandler();
+
+        $this->assertOutputMatches('Merged "2.3" into "2.5"');
+    }
+
+    /** @test */
+    public function it_merges_current_branch_into_next_version_branch_and_splits_repository()
+    {
+        $this->expectConfigHasSplits();
+
+        $this->splitshGit->checkPrecondition()->shouldBeCalled();
+        $this->splitshGit->splitTo('2.5', 'src/Component/Core', 'git@github.com:park-manager/core.git')->shouldBeCalled();
+        $this->splitshGit->splitTo('2.5', 'src/Component/Model', 'git@github.com:park-manager/model.git')->shouldBeCalled();
+        $this->splitshGit->splitTo('2.5', 'doc', 'git@github.com:park-manager/doc.git')->shouldBeCalled();
+
+        $this->git->getActiveBranchName()->willReturn('2.3');
+        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+
+        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6']);
+
+        $this->git->ensureBranchInSync('upstream', '2.3')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch('upstream', '2.5')->shouldBeCalled();
+        $this->git->ensureBranchInSync('upstream', '2.5')->shouldBeCalled();
+        $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
+
+        $this->git->checkout('2.3')->shouldBeCalled();
+        $this->git->pushToRemote('upstream', ['2.5'], true)->shouldBeCalled();
+
+        $this->executeHandler();
+
+        $this->assertOutputMatches('Merged "2.3" into "2.5"');
+    }
+
+    /** @test */
+    public function it_merges_current_branch_into_next_version_branch_and_skips_splitting_if_option_is_provided()
+    {
+        $this->expectConfigHasSplits();
+
+        $this->git->getActiveBranchName()->willReturn('2.3');
+        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+
+        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6']);
+
+        $this->git->ensureBranchInSync('upstream', '2.3')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch('upstream', '2.5')->shouldBeCalled();
+        $this->git->ensureBranchInSync('upstream', '2.5')->shouldBeCalled();
+        $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
+
+        $this->git->checkout('2.3')->shouldBeCalled();
+        $this->git->pushToRemote('upstream', ['2.5'], true)->shouldBeCalled();
+
+        $this->executeHandler($this->getArgs()->setOption('no-split', true));
 
         $this->assertOutputMatches('Merged "2.3" into "2.5"');
     }
@@ -183,6 +259,96 @@ class UpMergeHandlerTest extends TestCase
     }
 
     /** @test */
+    public function it_merges_current_branch_into_next_version_branches_and_updates_split()
+    {
+        $this->expectConfigHasSplits();
+
+        $this->splitshGit->checkPrecondition()->shouldBeCalled();
+
+        foreach (['2.5', '2.6', '2.x', 'master'] as $branchTarget) {
+            $this->splitshGit->splitTo($branchTarget, 'src/Component/Core', 'git@github.com:park-manager/core.git')->shouldBeCalled();
+            $this->splitshGit->splitTo($branchTarget, 'src/Component/Model', 'git@github.com:park-manager/model.git')->shouldBeCalled();
+            $this->splitshGit->splitTo($branchTarget, 'doc', 'git@github.com:park-manager/doc.git')->shouldBeCalled();
+        }
+
+        $this->git->getActiveBranchName()->willReturn('2.3');
+        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+
+        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6', '2.x']);
+
+        $this->git->ensureBranchInSync('upstream', '2.3')->shouldBeCalled();
+
+        $this->git->checkoutRemoteBranch('upstream', '2.5')->shouldBeCalled();
+        $this->git->ensureBranchInSync('upstream', '2.5')->shouldBeCalled();
+        $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
+
+        $this->git->checkoutRemoteBranch('upstream', '2.6')->shouldBeCalled();
+        $this->git->ensureBranchInSync('upstream', '2.6')->shouldBeCalled();
+        $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.5'])->shouldBeCalled();
+
+        $this->git->checkoutRemoteBranch('upstream', '2.x')->shouldBeCalled();
+        $this->git->ensureBranchInSync('upstream', '2.x')->shouldBeCalled();
+        $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.6'])->shouldBeCalled();
+
+        $this->git->checkoutRemoteBranch('upstream', 'master')->shouldBeCalled();
+        $this->git->ensureBranchInSync('upstream', 'master')->shouldBeCalled();
+        $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.x'])->shouldBeCalled();
+
+        $this->git->checkout('2.3')->shouldBeCalled();
+        $this->git->pushToRemote('upstream', ['2.5', '2.6', '2.x', 'master'], true)->shouldBeCalled();
+
+        $this->executeHandler($this->getArgs()->setOption('all', true));
+
+        $this->assertOutputMatches([
+            'Merged "2.3" into "2.5"',
+            'Merged "2.5" into "2.6"',
+            'Merged "2.6" into "2.x"',
+            'Merged "2.x" into "master"',
+        ]);
+    }
+
+    /** @test */
+    public function it_merges_current_branch_into_next_version_branches_and_skips_splitting_if_option_is_provided()
+    {
+        $this->expectConfigHasSplits();
+
+        $this->git->getActiveBranchName()->willReturn('2.3');
+        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+
+        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6', '2.x']);
+
+        $this->git->ensureBranchInSync('upstream', '2.3')->shouldBeCalled();
+
+        $this->git->checkoutRemoteBranch('upstream', '2.5')->shouldBeCalled();
+        $this->git->ensureBranchInSync('upstream', '2.5')->shouldBeCalled();
+        $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
+
+        $this->git->checkoutRemoteBranch('upstream', '2.6')->shouldBeCalled();
+        $this->git->ensureBranchInSync('upstream', '2.6')->shouldBeCalled();
+        $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.5'])->shouldBeCalled();
+
+        $this->git->checkoutRemoteBranch('upstream', '2.x')->shouldBeCalled();
+        $this->git->ensureBranchInSync('upstream', '2.x')->shouldBeCalled();
+        $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.6'])->shouldBeCalled();
+
+        $this->git->checkoutRemoteBranch('upstream', 'master')->shouldBeCalled();
+        $this->git->ensureBranchInSync('upstream', 'master')->shouldBeCalled();
+        $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.x'])->shouldBeCalled();
+
+        $this->git->checkout('2.3')->shouldBeCalled();
+        $this->git->pushToRemote('upstream', ['2.5', '2.6', '2.x', 'master'], true)->shouldBeCalled();
+
+        $this->executeHandler($this->getArgs()->setOption('all', true)->setOption('no-split', true));
+
+        $this->assertOutputMatches([
+            'Merged "2.3" into "2.5"',
+            'Merged "2.5" into "2.6"',
+            'Merged "2.6" into "2.x"',
+            'Merged "2.x" into "master"',
+        ]);
+    }
+
+    /** @test */
     public function it_does_nothing_with_all_when_current_branch_is_not_a_version()
     {
         $this->git->getActiveBranchName()->willReturn('master');
@@ -253,6 +419,7 @@ class UpMergeHandlerTest extends TestCase
         $format = ArgsFormat::build()
             ->addOption(new Option('all', null, Option::NO_VALUE | Option::BOOLEAN))
             ->addOption(new Option('dry-run', null, Option::NO_VALUE | Option::BOOLEAN))
+            ->addOption(new Option('no-split', null, Option::NO_VALUE | Option::BOOLEAN))
             ->addArgument(new Argument('branch', Argument::OPTIONAL | Argument::STRING))
             ->getFormat()
         ;
@@ -264,7 +431,27 @@ class UpMergeHandlerTest extends TestCase
     {
         $style = $this->createStyle();
 
-        $handler = new UpMergeHandler($style, $this->git->reveal(), $this->github->reveal(), $this->process->reveal());
+        $handler = new UpMergeHandler($style, $this->git->reveal(), $this->github->reveal(), $this->process->reveal(), $this->config, $this->splitshGit->reveal());
         $handler->handle($args ?? $this->getArgs());
+    }
+
+    private function expectConfigHasSplits(): void
+    {
+        $this->config = new Config(
+            [
+                'repos' => [
+                    'github.com' => [
+                        'park-manager/hubkit' => [
+                            'sync-tags' => true,
+                            'split' => [
+                                'src/Component/Core' => 'git@github.com:park-manager/core.git',
+                                'src/Component/Model' => 'git@github.com:park-manager/model.git',
+                                'doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => false],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
     }
 }

--- a/tests/Service/SplitshGitTest.php
+++ b/tests/Service/SplitshGitTest.php
@@ -55,7 +55,7 @@ class SplitshGitTest extends TestCase
             $service = new SplitshGit($git, $cliProcess, $filesystem, self::SPLITSH_EXECUTABLE);
 
             self::assertEquals(
-                ['_core' => ['2c00338aef823d0c0916fc1b59ef49d0bb76f02f', 'git@github.com:park-manager/core.git', 5]],
+                ['_core' => ['2c00338aef823d0c0916fc1b59ef49d0bb76f02f', 'git@github.com:park-manager/core.git']],
                 $service->splitTo('master', 'src/Bundle/CoreBundle', 'git@github.com:park-manager/core.git')
             );
         } finally {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #61 
| License       | MIT

Yes! The `upmerge` command now automatically splits the repository (if configured) after each upmerge operation. After the hook scripts for the release command this is another killer feature I'm very proud of.

Note: As a side-effect splitting the repository now always pushes as the commit count detection was error prone. And temporary branches are now finally removed.