### PR TITLE
[Release] Fix syncing of split-repo tags

### DIFF
--- a/src/Cli/Handler/ReleaseHandler.php
+++ b/src/Cli/Handler/ReleaseHandler.php
@@ -243,7 +243,7 @@ final class ReleaseHandler extends GitBaseHandler
             $progressBar->advance();
             $split = $this->splitshGit->splitTo($branch, $prefix, \is_array($config) ? $config['url'] : $config);
 
-            if (($config['sync-tags'] ?? $reposConfig['sync-tags'] ?? true)) {
+            if ($split !== null && ($config['sync-tags'] ?? $reposConfig['sync-tags'] ?? true)) {
                 $splits += $split;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #56 
| License       | MIT

It turned-out to me much easier to fix this than expected. When the prefix directory doesn't exist ignore the tagging for that repository.