### PR TITLE
Use origin/master when running a local upgrade

### DIFF
--- a/bin/upgrade
+++ b/bin/upgrade
@@ -20,7 +20,7 @@ if [ ${branchName} == "master" ]; then
     git rebase origin/master || (echo "Something went wrong, please try again" && exit 1)
 fi
 
-latest=`git describe --tags --abbrev=0 master`
+latest=`git describe --tags --abbrev=0 origin/master`
 
 git checkout "tags/${latest}" -b "version-${latest}" || echo "Branch already exists it seems"
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

I did a checkout of hubkit quite some time ago (my master branch was 36 commits behind) and I wanted to upgrade to the release of this morning. But the upgrade script only fetches from origin and doesn't merge the origin/master in my local master. 

This causes `git describe --tags --abbrev=0 master` to still return the tag related to 36 commits ago. By using `origin/master` in the tags lookup it will always return the latest and correct one!