### PR TITLE
Improve install/upgrade by trying global composer command first

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+composerRun() {
+    # Try global composer first otherwise fallback to composer.phar
+    if hash composer 2>/dev/null; then
+        composer "$@"
+    else
+        composer.phar "$@"
+    fi
+}
+
 echo "Installing HubKit please wait..."
 echo ""
 
@@ -12,7 +21,7 @@ if [ ${branchName} == "master" ]; then
     echo ""
 fi
 
-composer.phar install -o --no-dev || (echo "Composer did not succeed." && exit 1)
+composerRun install -o --no-dev || (echo "Composer did not succeed." && exit 1)
 
 if [ ! -f ./config.php ]; then
     echo -n "Copying config.php.dist to config.php"

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+composerRun() {
+    # Try global composer first otherwise fallback to composer.phar
+    if hash composer 2>/dev/null; then
+        composer "$@"
+    else
+        composer.phar "$@"
+    fi
+}
+
 echo "Upgrading HubKit please wait..."
 echo ""
 
@@ -24,7 +33,8 @@ latest=`git describe --tags --abbrev=0 origin/master`
 
 git checkout "tags/${latest}" -b "version-${latest}" || echo "Branch already exists it seems"
 
-composer.phar install -o --no-dev
+composerRun install -o --no-dev
+
 ./bin/hubkit.php self-diagnose || echo "Please see UPGRADE.md if you were asked to update your configuration."
 
 echo "You are now using version ${latest}, previous was ${branchName}"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

I only have composer globally installed and hubkit doesn't come with a composer.phar or the installation mention downloading it, so it will possibly always error on first install. 
So I've updated the install and upgrade script to check if composer is globally installed, otherwise it does a fallback to composer.phar in the local directory.