### PR TITLE
During release changelog edit must use TTY and wait for process to terminate

### DIFF
--- a/src/Service/CliProcess.php
+++ b/src/Service/CliProcess.php
@@ -39,6 +39,23 @@ class CliProcess
     }
 
     /**
+     * Runs an external process and waits until it is terminated.
+     *
+     * @param Process $process
+     *
+     * @throws ProcessFailedException
+     */
+    public function startAndWait(Process $process)
+    {
+        $process->start();
+        $process->wait();
+
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+    }
+
+    /**
      * Runs an external process.
      *
      * @param string|array|Process $cmd       An instance of Process or an array of arguments to escape and run or a command to run

--- a/src/Service/Editor.php
+++ b/src/Service/Editor.php
@@ -41,9 +41,10 @@ class Editor
         $tmpName = $this->filesystem->newTempFilename($contents);
 
         $process = new Process([$editor, $tmpName]);
+        $process->setTty(true);
         $process->setTimeout(null);
 
-        $this->process->mustRun($process);
+        $this->process->startAndWait($process);
         $contents = file_get_contents($tmpName);
 
         if ('' !== $instructions) {

--- a/tests/Unit/Service/EditorTest.php
+++ b/tests/Unit/Service/EditorTest.php
@@ -25,6 +25,10 @@ final class EditorTest extends TestCase
     /** @test */
     public function opens_editor_with_string_contents(): void
     {
+        if (false === $this->isTtySupported()) {
+            $this->markTestSkipped('No TTY support');
+        }
+
         $process = $this->createProcessSpy($processCmd);
         $filesystem = $this->createFilesystemSpy($tempFile);
         $editor = $this->createEditorWithMockEditor($process, $filesystem);
@@ -78,6 +82,10 @@ final class EditorTest extends TestCase
     /** @test */
     public function opens_editor_with_string_contents_and_instructions(): void
     {
+        if (false === $this->isTtySupported()) {
+            $this->markTestSkipped('No TTY support');
+        }
+
         $process = $this->createProcessSpy($processCmd);
         $filesystem = $this->createFilesystemSpy($tempFile);
         $editor = $this->createEditorWithMockEditor($process, $filesystem);
@@ -92,6 +100,10 @@ final class EditorTest extends TestCase
     /** @test */
     public function opens_editor_with_string_contents_and_instructions_removed(): void
     {
+        if (false === $this->isTtySupported()) {
+            $this->markTestSkipped('No TTY support');
+        }
+
         $filesystem = $this->createFilesystemSpy($tempFile);
         $process = $this->createProcessModifierSpy($processCmd, $tempFile, '# THIS LINE IS Some contents go here.');
         $editor = $this->createEditorWithMockEditor($process, $filesystem);
@@ -131,5 +143,10 @@ final class EditorTest extends TestCase
         $this->expectExceptionMessage('No content found. User aborted.');
 
         $editor->abortWhenEmpty(' ');
+    }
+
+    private function isTtySupported(): bool
+    {
+        return (bool) @proc_open('echo 1 >/dev/null', [['file', '/dev/tty', 'r'], ['file', '/dev/tty', 'w'], ['file', '/dev/tty', 'w']], $pipes);
     }
 }

--- a/tests/Unit/Service/EditorTest.php
+++ b/tests/Unit/Service/EditorTest.php
@@ -52,7 +52,7 @@ final class EditorTest extends TestCase
     {
         $processProphecy = $this->prophesize(CliProcess::class);
         $processProphecy
-            ->mustRun(
+            ->startAndWait(
                 Argument::that(
                     function (Process $process) use (&$processCmd) {
                         $processCmd = $process->getCommandLine();
@@ -107,7 +107,7 @@ final class EditorTest extends TestCase
     {
         $processProphecy = $this->prophesize(CliProcess::class);
         $processProphecy
-            ->mustRun(
+            ->startAndWait(
                 Argument::that(
                     function (Process $process) use (&$processCmd, &$tempFile, $contents) {
                         $processCmd = $process->getCommandLine();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

While creating a new release for php-github-api I noticed that the release handler was stuck on the step here you can change the generated changelog

```
Working on KnpLabs/php-github-api (branch master)

 Provided version: 2.14.0
Preparing release 2.14.0 (target branch master)
Please wait...
```

2 problems occured here:

- Without `setTty(true)` my editor didn't open (vim in this case)
- And without the `$process->wait()` the process wouldn't detect if the editor was closed.

With these changes I was able to publish a new release and edit the changelog during the release!