### PR TITLE
Add question to squash pr during merge

### DIFF
--- a/src/Service/GitHub.php
+++ b/src/Service/GitHub.php
@@ -248,6 +248,30 @@ class GitHub
         )['commits'];
     }
 
+    public function getPullrequestCommitCount($id): int
+    {
+        $graphql = $this->client->graphql();
+        $query = <<<'QUERY'
+query($owner: String!, $repo: String!, $prNumber: Int!) { 
+  repository (owner: $owner, name: $repo) {
+    pullRequest (number: $prNumber) {
+      commits {
+        totalCount
+      }
+    }
+  }
+}
+QUERY;
+
+        $result = $graphql->execute($query, ['owner' => $this->organization, 'repo' => $this->repository, 'prNumber' => $id]);
+
+        if (!isset($result['data'])) {
+            throw new \RuntimeException('Unable to determine commit count for pullrequest.');
+        }
+
+        return (int) $result['data']['repository']['pullRequest']['commits']['totalCount'];
+    }
+
     public function updatePullRequest($id, array $parameters)
     {
         $api = $this->client->pullRequest();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

Sometimes when merging a PR, I forget to pass the `--squash` option even though the pr has multiple commits and should have been squashed. 
So I added an extra question to the merge command to explicitly ask the user if the commits should be squashed in case the `--squash` was not passed and the pr has multiple commits.