### PR TITLE
Allow to skip help message in pr base switch

### DIFF
--- a/src/Cli/Handler/SwitchBaseHandler.php
+++ b/src/Cli/Handler/SwitchBaseHandler.php
@@ -59,7 +59,10 @@ final class SwitchBaseHandler extends GitBaseHandler
         $this->deleteTempBranch($tmpBranch);
 
         $this->github->updatePullRequest($pullRequest['number'], ['base' => $newBase]);
-        $this->postHelpComment($pullRequest, $branch);
+
+        if (!$args->getOption('skip-help')) {
+            $this->postHelpComment($pullRequest, $branch);
+        }
 
         if ($this->git->branchExists($branch)) {
             $this->style->note(

--- a/src/Cli/HubKitApplicationConfig.php
+++ b/src/Cli/HubKitApplicationConfig.php
@@ -220,6 +220,7 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
                 ->setDescription('Switch the base of a pull request (and perform a rebase to prevent unwanted commits)')
                 ->addArgument('number', Argument::REQUIRED | Argument::INTEGER, 'The number of the pull request to switch')
                 ->addArgument('new-base', Argument::REQUIRED | Argument::STRING, 'New base of the pull-request (must exist in remote "upstream")')
+                ->addOption('skip-help', null, Option::NO_VALUE | Option::BOOLEAN, 'Skip the help message posted to the PR.')
                 ->setHandler(function () {
                     return new Handler\SwitchBaseHandler(
                         $this->container['style'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

Sometimes when a pr is just a small change but must be applied to a lower version branch, I just switch branches before merging so the help message is not needed at that point. This PR provides an option to skip that message with `--skip-help`