### PR TITLE
Don't change upstream tracking branch while upmerging

### DIFF
--- a/src/Cli/Handler/UpMergeHandler.php
+++ b/src/Cli/Handler/UpMergeHandler.php
@@ -174,7 +174,7 @@ final class UpMergeHandler extends GitBaseHandler
                 return 0;
             }
 
-            $this->git->pushToRemote('upstream', $changedBranches, true);
+            $this->git->pushToRemote('upstream', $changedBranches);
             $this->style->success('Branch(es) where merged.');
         } catch (\Exception $e) {
             $this->style->error(

--- a/tests/Handler/UpMergeHandlerTest.php
+++ b/tests/Handler/UpMergeHandlerTest.php
@@ -88,7 +88,7 @@ class UpMergeHandlerTest extends TestCase
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.5'], true)->shouldBeCalled();
+        $this->git->pushToRemote('upstream', ['2.5'])->shouldBeCalled();
 
         $this->executeHandler();
 
@@ -116,7 +116,7 @@ class UpMergeHandlerTest extends TestCase
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.5'], true)->shouldBeCalled();
+        $this->git->pushToRemote('upstream', ['2.5'])->shouldBeCalled();
 
         $this->executeHandler();
 
@@ -139,7 +139,7 @@ class UpMergeHandlerTest extends TestCase
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.5'], true)->shouldBeCalled();
+        $this->git->pushToRemote('upstream', ['2.5'])->shouldBeCalled();
 
         $this->executeHandler($this->getArgs()->setOption('no-split', true));
 
@@ -160,7 +160,7 @@ class UpMergeHandlerTest extends TestCase
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.x'], true)->shouldBeCalled();
+        $this->git->pushToRemote('upstream', ['2.x'])->shouldBeCalled();
 
         $this->executeHandler();
 
@@ -181,7 +181,7 @@ class UpMergeHandlerTest extends TestCase
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.6'])->shouldBeCalled();
 
         $this->git->checkout('2.6')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['master'], true)->shouldBeCalled();
+        $this->git->pushToRemote('upstream', ['master'])->shouldBeCalled();
 
         $this->executeHandler();
 
@@ -212,7 +212,7 @@ class UpMergeHandlerTest extends TestCase
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.5'], true)->shouldBeCalled();
+        $this->git->pushToRemote('upstream', ['2.5'])->shouldBeCalled();
 
         $this->executeHandler($this->getArgs()->setArgument('branch', '2.3'));
 
@@ -246,7 +246,7 @@ class UpMergeHandlerTest extends TestCase
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.x'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.5', '2.6', '2.x', 'master'], true)->shouldBeCalled();
+        $this->git->pushToRemote('upstream', ['2.5', '2.6', '2.x', 'master'])->shouldBeCalled();
 
         $this->executeHandler($this->getArgs()->setOption('all', true));
 
@@ -295,7 +295,7 @@ class UpMergeHandlerTest extends TestCase
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.x'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.5', '2.6', '2.x', 'master'], true)->shouldBeCalled();
+        $this->git->pushToRemote('upstream', ['2.5', '2.6', '2.x', 'master'])->shouldBeCalled();
 
         $this->executeHandler($this->getArgs()->setOption('all', true));
 
@@ -336,7 +336,7 @@ class UpMergeHandlerTest extends TestCase
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.x'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.5', '2.6', '2.x', 'master'], true)->shouldBeCalled();
+        $this->git->pushToRemote('upstream', ['2.5', '2.6', '2.x', 'master'])->shouldBeCalled();
 
         $this->executeHandler($this->getArgs()->setOption('all', true)->setOption('no-split', true));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

In my current setup the upmerge command changes the remote tracking my local branch, which is not intended while working in a fork with upstream setup (the branch will be changed from origin (my fork) to upstream (base repo) as the tracking remote. I don't know why this was added, so correct me if I'm wrong, but I think the upstream remote change is not needed here? A `git push upstream xxx-branch` would be enough I think