### PR TITLE
Throw exception why merging PR with deleted source repo

### DIFF
--- a/src/Cli/Handler/MergeHandler.php
+++ b/src/Cli/Handler/MergeHandler.php
@@ -222,6 +222,10 @@ final class MergeHandler extends GitBaseHandler
         $message .= $pr['body'];
         $message .= "\n\nCommits\n-------\n\n";
 
+        if (null === $pr['head']['repo']) {
+            throw new \RuntimeException('Can\'t merge this PR as the source repository (fork) was deleted.');
+        }
+
         $commits = $this->github->getCommits(
             $pr['head']['user']['login'],
             $pr['head']['repo']['name'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Features and deprecations must be submitted against branch master.
-->

This PR fixes the error when merging a PR where the created of PR removed their fork of the repository. 

Example:
<img width="298" alt="Screenshot 2021-01-24 at 17 22 06" src="https://user-images.githubusercontent.com/1374857/105636635-52e13500-5e69-11eb-9581-6d5b7e715246.png">

When merging this PR the code (php 7.4) just throws an notice/exception without much info. So I've added a check to only continue if the source repo still exists. Otherwise the call the get all pr commits will fail.

Current error: `fatal: Notice: Trying to access array offset on value of type null`
New error: `fatal: Can't merge this PR as the source repository (fork) was deleted.`

Not sure if that message is clear, so I'm open to suggestions!

And btw @sstok congrats on the 1.0.0 stable release, I've totally missed that! 😄 