### PR TITLE
Fix github actions config to trigger build again after branch rename

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,10 +2,10 @@ name: Full CI process
 on:
     push:
         branches:
-            - master
+            - $default-branch
     pull_request:
         branches:
-            - master
+            - $default-branch
 
 jobs:
     test:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes(ish)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

With the renamed default branch the builds didn't trigger anymore in my last pr's. So I've updated the github actions config to work again, this change uses the new `$default-branch` env var github introduced when they added support for easily renaming default branches (https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/)