### PR TITLE
Allow upmerging repositories without a master branch

### DIFF
--- a/src/Cli/Handler/UpMergeHandler.php
+++ b/src/Cli/Handler/UpMergeHandler.php
@@ -55,7 +55,7 @@ final class UpMergeHandler extends GitBaseHandler
         return $this->handleMerge($args, $branch);
     }
 
-    private function mergeAllBranches(string $branch, array $splitTargets): array
+    private function mergeAllBranches(string $branch, array $splitTargets, string $defaultBranch): array
     {
         $branches = $this->git->getVersionBranches('upstream');
 
@@ -66,7 +66,9 @@ final class UpMergeHandler extends GitBaseHandler
 
         $this->git->ensureBranchInSync('upstream', $branch);
 
-        $branches[] = 'master';
+        if (!\in_array($defaultBranch, $branches, true)) {
+            $branches[] = $defaultBranch;
+        }
         $changedBranches = [];
 
         for ($i = $idx + 1, $c = \count($branches); $i < $c; ++$i) {
@@ -111,7 +113,7 @@ final class UpMergeHandler extends GitBaseHandler
         return [$nextVersion];
     }
 
-    private function dryMergeAllBranches(string $branch): array
+    private function dryMergeAllBranches(string $branch, string $defaultBranch): array
     {
         $branches = $this->git->getVersionBranches('upstream');
 
@@ -124,7 +126,9 @@ final class UpMergeHandler extends GitBaseHandler
 
         $this->git->ensureBranchInSync('upstream', $branch);
 
-        $branches[] = 'master';
+        if (!\in_array($defaultBranch, $branches, true)) {
+            $branches[] = $defaultBranch;
+        }
         $changedBranches = [];
 
         for ($i = $idx + 1, $c = \count($branches); $i < $c; ++$i) {
@@ -163,7 +167,9 @@ final class UpMergeHandler extends GitBaseHandler
     {
         try {
             if ($args->getOption('all')) {
-                $changedBranches = $this->mergeAllBranches($branch, $this->getSplitTargets($args));
+                $defaultBranch = $this->github->getDefaultBranch();
+
+                $changedBranches = $this->mergeAllBranches($branch, $this->getSplitTargets($args), $defaultBranch);
             } else {
                 $changedBranches = $this->mergeSingleBranch($branch, $this->getSplitTargets($args));
             }
@@ -195,7 +201,9 @@ final class UpMergeHandler extends GitBaseHandler
     {
         try {
             if ($args->getOption('all')) {
-                $changedBranches = $this->dryMergeAllBranches($branch);
+                $defaultBranch = $this->github->getDefaultBranch();
+
+                $changedBranches = $this->dryMergeAllBranches($branch, $defaultBranch);
             } else {
                 $changedBranches = $this->dryMergeSingleBranch($branch);
             }

--- a/src/Service/GitHub.php
+++ b/src/Service/GitHub.php
@@ -329,6 +329,13 @@ QUERY;
         );
     }
 
+    public function getDefaultBranch(): string
+    {
+        $repo = $this->client->repo()->show($this->getOrganization(), $this->getRepository());
+
+        return $repo['default_branch'];
+    }
+
     private static function getValuesFromNestedArray(array $array, string $key)
     {
         $values = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT

In a repository where I use hubkit on, we don't have a master or main branch but only version branches.

So we have
- 5.10
- 6.0
- 6.1
- 6.x (which is the main branch where new versions are developed on) 

So I've updated the code to include the default branch in list of upmerge branches if it is not already part of it. This way setups with a master default branch (or even the newer main branch) will still work but also support these kind of cases.