### PR TITLE
Don't use shalowing cloning for splitting

### DIFF
--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -66,6 +66,10 @@ class Git
             $remoteBranch = $localBranch;
         }
 
+        if (! $this->remoteBranchExists($remoteName, $remoteBranch)) {
+            return self::STATUS_NEED_PUSH;
+        }
+
         $localRef = $this->process->mustRun(['git', 'rev-parse', $localBranch])->getOutput();
         $remoteRef = $this->process->mustRun(['git', 'rev-parse', 'refs/remotes/' . $remoteName . '/' . $remoteBranch])->getOutput();
         $baseRef = $this->process->mustRun(['git', 'merge-base', $localBranch, 'refs/remotes/' . $remoteName . '/' . $remoteBranch])->getOutput();

--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -364,7 +364,7 @@ class Git
             return;
         }
 
-        $this->process->mustRun(['git', 'checkout', $remote . '/' . $branchName, '-b', $branchName]);
+        $this->process->mustRun(['git', 'checkout', 'remotes/' . $remote . '/' . $branchName, '-b', $branchName]);
     }
 
     public function guardWorkingTreeReady(): void

--- a/src/Service/SplitshGit.php
+++ b/src/Service/SplitshGit.php
@@ -66,23 +66,7 @@ class SplitshGit
         $tempBranchName = null;
 
         // NOTE: Always perform the push as git-splitsh in some cases don't produce a new commit as there was already one
-        try {
-            $this->git->pushToRemote($remoteName, $sha . ':' . $targetBranch);
-        } catch (ProcessFailedException $e) {
-            // Failed to push. If remote branch is missing Git fails.
-            if ($this->git->remoteBranchExists($remoteName, $targetBranch)) {
-                throw $e;
-            }
-
-            $this->git->checkout($sha);
-            $this->git->checkout($tempBranchName = '_tmp_' . $sha, true);
-            $this->git->pushToRemote($remoteName, $tempBranchName . ':' . $targetBranch);
-        } finally {
-            if ($tempBranchName !== null) {
-                $this->git->checkout($targetBranch);
-                $this->git->deleteBranchWithForce($tempBranchName);
-            }
-        }
+        $this->git->pushToRemote($remoteName, $sha . ':refs/heads/' . $targetBranch);
 
         return [$remoteName => [$sha, $url]];
     }

--- a/src/Service/SplitshGit.php
+++ b/src/Service/SplitshGit.php
@@ -112,8 +112,8 @@ class SplitshGit
                 throw new \RuntimeException('Unable to change to temp repository. Aborting.');
             }
 
-            $this->git->clone($url, 'origin', 200);
-            $this->git->checkout($branch);
+            $this->git->clone($url, 'origin');
+            $this->git->checkoutRemoteBranch('origin', $branch);
 
             try {
                 $this->process->mustRun(['git', 'tag', 'v' . $versionStr, $targetCommit, '-s', '-m', 'Release ' . $versionStr]);

--- a/tests/Functional/Service/Git/GitBranchTest.php
+++ b/tests/Functional/Service/Git/GitBranchTest.php
@@ -63,6 +63,12 @@ final class GitBranchTest extends TestCase
     }
 
     /** @test */
+    public function it_returns_needs_push_when_remote_branch_is_missing(): void
+    {
+        self::assertEquals(GitBranch::STATUS_NEED_PUSH, $this->git->getRemoteDiffStatus('origin', '2.0'));
+    }
+
+    /** @test */
     public function it_returns_needs_pull_when_remote_is_ahead(): void
     {
         $this->runCliCommand(['git', 'reset', '--hard', 'HEAD@{1}'], $this->localRepository);

--- a/tests/Service/SplitshGitTest.php
+++ b/tests/Service/SplitshGitTest.php
@@ -76,9 +76,9 @@ final class SplitshGitTest extends TestCase
         $gitProphecy = $this->prophesize(Git::class);
         $gitProphecy->getGitConfig('remote._core.url')->willReturn('git@github.com:park-manager/core.git');
         $gitProphecy->getGitConfig('remote._user.url')->willReturn('git@github.com:park-manager/user.git');
-        $gitProphecy->clone('git@github.com:park-manager/core.git', 'origin', 200)->shouldBeCalledTimes(1);
-        $gitProphecy->clone('git@github.com:park-manager/user.git', 'origin', 200)->shouldBeCalledTimes(1);
-        $gitProphecy->checkout('1.0')->shouldBeCalledTimes(2);
+        $gitProphecy->clone('git@github.com:park-manager/core.git', 'origin')->shouldBeCalledTimes(1);
+        $gitProphecy->clone('git@github.com:park-manager/user.git', 'origin')->shouldBeCalledTimes(1);
+        $gitProphecy->checkoutRemoteBranch('origin', '1.0')->shouldBeCalledTimes(2);
 
         $git = $gitProphecy->reveal();
 

--- a/tests/Service/SplitshGitTest.php
+++ b/tests/Service/SplitshGitTest.php
@@ -43,7 +43,7 @@ final class SplitshGitTest extends TestCase
             $gitProphecy = $this->prophesize(Git::class);
             $gitProphecy->isGitDir()->willReturn(true);
             $gitProphecy->ensureRemoteExists('_core', 'git@github.com:park-manager/core.git')->shouldBeCalled();
-            $gitProphecy->pushToRemote('_core', '2c00338aef823d0c0916fc1b59ef49d0bb76f02f:master')->shouldBeCalled();
+            $gitProphecy->pushToRemote('_core', '2c00338aef823d0c0916fc1b59ef49d0bb76f02f:refs/heads/master')->shouldBeCalled();
             $git = $gitProphecy->reveal();
 
             $processProphecy = $this->prophesize(Process::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

In some cases this doesn't bring-up all branches, secondly GitHub recommends against using shallow clones.

