### PR TITLE
Repository splitting improvements

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -155,3 +155,9 @@ then once all conflicts are resolved. Run the `switch-base` command (with the or
 again and it will continue as normal.
 
 **Do not push these changes manually as this will not update the pull-request target base.**
+
+### cache-clear
+
+Clears the cache Hubkit uses to split repositories and store resolved configuration branches.
+
+**Tip:** Use the `-v` option to show how much space was retrieved.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,11 +121,6 @@ parameters:
 			path: src/Cli/Handler/MergeHandler.php
 
 		-
-			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\MergeHandler\\:\\:splitRepository\\(\\) has parameter \\$pr with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Cli/Handler/MergeHandler.php
-
-		-
 			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\MergeHandler\\:\\:validateMessages\\(\\) has parameter \\$commits with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Cli/Handler/MergeHandler.php
@@ -146,11 +141,6 @@ parameters:
 			path: src/Cli/Handler/MergeHandler.php
 
 		-
-			message: "#^Property HubKit\\\\Cli\\\\Handler\\\\MergeHandler\\:\\:\\$splitshGit has no type specified\\.$#"
-			count: 1
-			path: src/Cli/Handler/MergeHandler.php
-
-		-
 			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\ReleaseHandler\\:\\:guardTagDoesNotExist\\(\\) has parameter \\$tags with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Cli/Handler/ReleaseHandler.php
@@ -167,11 +157,6 @@ parameters:
 
 		-
 			message: "#^Property HubKit\\\\Cli\\\\Handler\\\\ReleaseHandler\\:\\:\\$releaseHooks has no type specified\\.$#"
-			count: 1
-			path: src/Cli/Handler/ReleaseHandler.php
-
-		-
-			message: "#^Property HubKit\\\\Cli\\\\Handler\\\\ReleaseHandler\\:\\:\\$splitshGit has no type specified\\.$#"
 			count: 1
 			path: src/Cli/Handler/ReleaseHandler.php
 
@@ -211,21 +196,6 @@ parameters:
 			path: src/Cli/Handler/SelfDiagnoseHandler.php
 
 		-
-			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\SplitRepoHandler\\:\\:drySplitRepository\\(\\) has parameter \\$repos with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Cli/Handler/SplitRepoHandler.php
-
-		-
-			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\SplitRepoHandler\\:\\:splitRepository\\(\\) has parameter \\$repos with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Cli/Handler/SplitRepoHandler.php
-
-		-
-			message: "#^Property HubKit\\\\Cli\\\\Handler\\\\SplitRepoHandler\\:\\:\\$splitshGit has no type specified\\.$#"
-			count: 1
-			path: src/Cli/Handler/SplitRepoHandler.php
-
-		-
 			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\SwitchBaseHandler\\:\\:postHelpComment\\(\\) has parameter \\$pullRequest with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Cli/Handler/SwitchBaseHandler.php
@@ -256,11 +226,6 @@ parameters:
 			path: src/Cli/Handler/UpMergeHandler.php
 
 		-
-			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\UpMergeHandler\\:\\:getSplitTargets\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Cli/Handler/UpMergeHandler.php
-
-		-
 			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\UpMergeHandler\\:\\:handle\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Cli/Handler/UpMergeHandler.php
@@ -271,22 +236,7 @@ parameters:
 			path: src/Cli/Handler/UpMergeHandler.php
 
 		-
-			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\UpMergeHandler\\:\\:handleDryMerge\\(\\) has parameter \\$branch with no type specified\\.$#"
-			count: 1
-			path: src/Cli/Handler/UpMergeHandler.php
-
-		-
 			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\UpMergeHandler\\:\\:handleMerge\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Cli/Handler/UpMergeHandler.php
-
-		-
-			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\UpMergeHandler\\:\\:handleMerge\\(\\) has parameter \\$branch with no type specified\\.$#"
-			count: 1
-			path: src/Cli/Handler/UpMergeHandler.php
-
-		-
-			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\UpMergeHandler\\:\\:mergeAllBranches\\(\\) has parameter \\$splitTargets with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Cli/Handler/UpMergeHandler.php
 
@@ -296,17 +246,7 @@ parameters:
 			path: src/Cli/Handler/UpMergeHandler.php
 
 		-
-			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\UpMergeHandler\\:\\:mergeSingleBranch\\(\\) has parameter \\$splitTargets with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Cli/Handler/UpMergeHandler.php
-
-		-
 			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\UpMergeHandler\\:\\:mergeSingleBranch\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Cli/Handler/UpMergeHandler.php
-
-		-
-			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\UpMergeHandler\\:\\:splitRepository\\(\\) has parameter \\$splitTargets with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Cli/Handler/UpMergeHandler.php
 
@@ -316,13 +256,8 @@ parameters:
 			path: src/Cli/Handler/UpMergeHandler.php
 
 		-
-			message: "#^Property HubKit\\\\Cli\\\\Handler\\\\UpMergeHandler\\:\\:\\$splitshGit has no type specified\\.$#"
-			count: 1
-			path: src/Cli/Handler/UpMergeHandler.php
-
-		-
 			message: "#^Call to an undefined method Webmozart\\\\Console\\\\Api\\\\Config\\\\ApplicationConfig\\|Webmozart\\\\Console\\\\Api\\\\Config\\\\CommandConfig\\:\\:end\\(\\)\\.$#"
-			count: 13
+			count: 14
 			path: src/Cli/HubKitApplicationConfig.php
 
 		-
@@ -846,41 +781,6 @@ parameters:
 			path: src/Service/ReleaseHooks.php
 
 		-
-			message: "#^Method HubKit\\\\Service\\\\SplitshGit\\:\\:splitTo\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Service/SplitshGit.php
-
-		-
-			message: "#^Method HubKit\\\\Service\\\\SplitshGit\\:\\:syncTags\\(\\) has parameter \\$targets with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Service/SplitshGit.php
-
-		-
-			message: "#^Property HubKit\\\\Service\\\\SplitshGit\\:\\:\\$executable has no type specified\\.$#"
-			count: 1
-			path: src/Service/SplitshGit.php
-
-		-
-			message: "#^Property HubKit\\\\Service\\\\SplitshGit\\:\\:\\$filesystem has no type specified\\.$#"
-			count: 1
-			path: src/Service/SplitshGit.php
-
-		-
-			message: "#^Property HubKit\\\\Service\\\\SplitshGit\\:\\:\\$git has no type specified\\.$#"
-			count: 1
-			path: src/Service/SplitshGit.php
-
-		-
-			message: "#^Property HubKit\\\\Service\\\\SplitshGit\\:\\:\\$logger has no type specified\\.$#"
-			count: 1
-			path: src/Service/SplitshGit.php
-
-		-
-			message: "#^Property HubKit\\\\Service\\\\SplitshGit\\:\\:\\$process has no type specified\\.$#"
-			count: 1
-			path: src/Service/SplitshGit.php
-
-		-
 			message: "#^Method HubKit\\\\StringUtil\\:\\:splitLines\\(\\) should return array\\<string\\> but returns array\\<int, string\\>\\|false\\.$#"
 			count: 1
 			path: src/StringUtil.php
@@ -1376,11 +1276,6 @@ parameters:
 			path: tests/Handler/MergeHandlerTest.php
 
 		-
-			message: "#^Parameter \\#7 \\$splitshGit of class HubKit\\\\Cli\\\\Handler\\\\MergeHandler constructor expects HubKit\\\\Service\\\\SplitshGit, object given\\.$#"
-			count: 1
-			path: tests/Handler/MergeHandlerTest.php
-
-		-
 			message: "#^Property HubKit\\\\Tests\\\\Handler\\\\MergeHandlerTest\\:\\:\\$aliasResolver with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
 			count: 1
 			path: tests/Handler/MergeHandlerTest.php
@@ -1397,11 +1292,6 @@ parameters:
 
 		-
 			message: "#^Property HubKit\\\\Tests\\\\Handler\\\\MergeHandlerTest\\:\\:\\$output \\(Symfony\\\\Component\\\\Console\\\\Output\\\\StreamOutput\\) does not accept Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface\\.$#"
-			count: 1
-			path: tests/Handler/MergeHandlerTest.php
-
-		-
-			message: "#^Property HubKit\\\\Tests\\\\Handler\\\\MergeHandlerTest\\:\\:\\$splitshGit with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
 			count: 1
 			path: tests/Handler/MergeHandlerTest.php
 
@@ -1506,11 +1396,6 @@ parameters:
 			path: tests/Handler/ReleaseHandlerTest.php
 
 		-
-			message: "#^Parameter \\#7 \\$splitshGit of class HubKit\\\\Cli\\\\Handler\\\\ReleaseHandler constructor expects HubKit\\\\Service\\\\SplitshGit, object given\\.$#"
-			count: 1
-			path: tests/Handler/ReleaseHandlerTest.php
-
-		-
 			message: "#^Property HubKit\\\\Tests\\\\Handler\\\\ReleaseHandlerTest\\:\\:\\$editor with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
 			count: 1
 			path: tests/Handler/ReleaseHandlerTest.php
@@ -1532,11 +1417,6 @@ parameters:
 
 		-
 			message: "#^Property HubKit\\\\Tests\\\\Handler\\\\ReleaseHandlerTest\\:\\:\\$process with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
-			count: 1
-			path: tests/Handler/ReleaseHandlerTest.php
-
-		-
-			message: "#^Property HubKit\\\\Tests\\\\Handler\\\\ReleaseHandlerTest\\:\\:\\$splitshGit with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
 			count: 1
 			path: tests/Handler/ReleaseHandlerTest.php
 
@@ -1587,11 +1467,6 @@ parameters:
 
 		-
 			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\SplitRepoHandlerTest\\:\\:executeHandler\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Handler/SplitRepoHandlerTest.php
-
-		-
-			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\SplitRepoHandlerTest\\:\\:expectGitSplit\\(\\) has parameter \\$targetBranch with no type specified\\.$#"
 			count: 1
 			path: tests/Handler/SplitRepoHandlerTest.php
 
@@ -1784,6 +1659,96 @@ parameters:
 			message: "#^Property HubKit\\\\Tests\\\\Helper\\\\ChangelogRendererTest\\:\\:\\$github with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
 			count: 1
 			path: tests/Helper/ChangelogRendererTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Service\\\\BranchSplitshTest\\:\\:assertOutputMatches\\(\\) has parameter \\$expectedLines with no type specified\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Service\\\\BranchSplitshTest\\:\\:assertOutputMatches\\(\\) has parameter \\$regex with no type specified\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Service\\\\BranchSplitshTest\\:\\:assertOutputNotMatches\\(\\) has parameter \\$lines with no type specified\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Service\\\\BranchSplitshTest\\:\\:assertOutputNotMatches\\(\\) has parameter \\$regex with no type specified\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Service\\\\BranchSplitshTest\\:\\:createStyle\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Service\\\\BranchSplitshTest\\:\\:getDisplay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Service\\\\BranchSplitshTest\\:\\:getInputStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Service\\\\BranchSplitshTest\\:\\:getInputStream\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^PHPDoc tag @var for property HubKit\\\\Tests\\\\Service\\\\BranchSplitshTest\\:\\:\\$git contains unresolvable type\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^PHPDoc tag @var for property HubKit\\\\Tests\\\\Service\\\\BranchSplitshTest\\:\\:\\$github contains unresolvable type\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^PHPDoc tag @var for property HubKit\\\\Tests\\\\Service\\\\BranchSplitshTest\\:\\:\\$splitshGit contains unresolvable type\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of class Symfony\\\\Component\\\\Console\\\\Output\\\\StreamOutput constructor expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fwrite expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function rewind expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertDoesNotMatchRegularExpression\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertMatchesRegularExpression\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
+
+		-
+			message: "#^Property HubKit\\\\Tests\\\\Service\\\\BranchSplitshTest\\:\\:\\$output \\(Symfony\\\\Component\\\\Console\\\\Output\\\\StreamOutput\\) does not accept Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface\\.$#"
+			count: 1
+			path: tests/Service/BranchSplitshTest.php
 
 		-
 			message: "#^Method HubKit\\\\Tests\\\\Service\\\\MessageValidatorTest\\:\\:createMessage\\(\\) has parameter \\$message with no type specified\\.$#"

--- a/src/Cli/Handler/ClearCacheHandler.php
+++ b/src/Cli/Handler/ClearCacheHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HubKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Cli\Handler;
+
+use HubKit\Service\Filesystem;
+use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Console\Api\Args\Args;
+use Webmozart\Console\Api\IO\IO;
+
+final class ClearCacheHandler
+{
+    public function __construct(private SymfonyStyle $style, private Filesystem $filesystem)
+    {
+    }
+
+    public function handle(Args $args, IO $io): int
+    {
+        $this->style->title('Clear Cache');
+
+        if ($io->isVerbose()) {
+            $files = 0;
+            $size = 0;
+
+            /** @var \SplFileInfo $file */
+            foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->filesystem->getTempdir(), \RecursiveDirectoryIterator::CURRENT_AS_FILEINFO | \RecursiveDirectoryIterator::SKIP_DOTS)) as $file) {
+                if (! $file->isFile()) {
+                    continue;
+                }
+
+                $size += $file->getSize() ?: 0;
+                ++$files;
+            }
+
+            $this->style->comment(sprintf('Cache directory %s', $this->filesystem->getTempdir()));
+            $this->style->comment(sprintf('Removed %s file taking-up %s of space', $files, Helper::formatMemory($size)));
+        }
+
+        $this->filesystem->clearTempFolder();
+        $this->style->success('Cache was cleared.');
+
+        return 0;
+    }
+}

--- a/src/Cli/Handler/SplitRepoHandler.php
+++ b/src/Cli/Handler/SplitRepoHandler.php
@@ -14,104 +14,52 @@ declare(strict_types=1);
 namespace HubKit\Cli\Handler;
 
 use HubKit\Config;
+use HubKit\Service\BranchSplitsh;
 use HubKit\Service\Git;
 use HubKit\Service\GitHub;
-use HubKit\Service\SplitshGit;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Webmozart\Console\Api\Args\Args;
 
 final class SplitRepoHandler extends GitBaseHandler
 {
-    private $splitshGit;
-
-    public function __construct(SymfonyStyle $style, SplitshGit $splitshGit, Git $git, GitHub $github, Config $config)
+    public function __construct(SymfonyStyle $style, private BranchSplitsh $branchSplitsh, Git $git, GitHub $github, Config $config)
     {
         parent::__construct($style, $git, $github, $config);
-        $this->splitshGit = $splitshGit;
-        $this->config = $config;
     }
 
-    public function handle(Args $args): int
+    public function handle(Args $args): void
     {
         $this->git->guardWorkingTreeReady();
         $this->git->remoteUpdate('upstream');
 
-        $branch = $args->getArgument('branch');
-
-        if ($branch !== null) {
-            $useCurrentBranch = false;
-        } else {
-            $branch = $this->git->getActiveBranchName();
-            $useCurrentBranch = true;
-        }
-
-        $config = $this->config->getBranchConfig($this->github->getHostname(), $this->github->getOrganization() . '/' . $this->github->getRepository(), $branch);
-        $split = $config->config['split'] ?? [];
-
-        if ($split === []) {
-            $configName = $config->configPath ?? [];
-
-            $this->style->error(
-                sprintf('Unable to split repository: No targets were found in config "[%s][split]", update the (local) configuration file.', implode('][', $configName))
-            );
-
-            return 2;
-        }
-
-        if (! $useCurrentBranch) {
-            $this->git->checkoutRemoteBranch('upstream', $branch);
-        }
+        $branch = $this->getBranchName($args);
 
         $this->style->title('Repository Split');
         $this->informationHeader($branch);
-        $this->style->text(sprintf('Split configuration resolved from branch <fg=yellow>%s</>.', $config->configName));
 
         if ($args->getOption('dry-run')) {
-            return $this->drySplitRepository($branch, $split);
-        }
-
-        return $this->splitRepository($branch, $split);
-    }
-
-    private function splitRepository(string $branch, array $repos): int
-    {
-        $this->git->ensureBranchInSync('upstream', $branch);
-        $this->splitshGit->checkPrecondition();
-
-        $this->style->section(sprintf('%s sources to split', \count($repos)));
-
-        foreach ($repos as $prefix => $config) {
-            if ($config['url'] === false) {
-                continue;
+            if ($this->branchSplitsh->drySplitBranch($branch) > 0) {
+                $this->style->success('[DRY-RUN] Repository directories were split into there destination.');
             }
 
-            $this->style->writeln(sprintf('<fg=default;bg=default> Splitting %s to %s</>', $prefix, $config['url']));
-            $this->splitshGit->splitTo($branch, $prefix, $config['url']);
+            return;
         }
 
-        $this->style->success('Repository directories were split into there destination.');
-
-        return 0;
+        if (\count($this->branchSplitsh->splitBranch($branch)) > 0) {
+            $this->style->success('Repository directories were split into there destination.');
+        }
     }
 
-    private function drySplitRepository(string $branch, array $repos): int
+    private function getBranchName(Args $args): string
     {
-        $this->git->ensureBranchInSync('upstream', $branch);
-        $this->splitshGit->checkPrecondition();
+        $branch = $args->getArgument('branch');
 
-        $this->style->section(sprintf('%s sources to split', \count($repos)));
-
-        foreach ($repos as $prefix => $config) {
-            if ($config['url'] === false) {
-                continue;
-            }
-
-            $this->style->writeln(sprintf('<fg=default;bg=default> [DRY-RUN] Splitting %s to %s</>', $prefix, $config['url']));
+        if ($branch === null) {
+            return $this->git->getActiveBranchName();
         }
 
-        $this->style->newLine();
-        $this->style->success('[DRY-RUN] Repository directories were split into there destination.');
+        $this->git->checkoutRemoteBranch('upstream', $branch);
 
-        return 0;
+        return $branch;
     }
 }

--- a/src/Cli/HubKitApplicationConfig.php
+++ b/src/Cli/HubKitApplicationConfig.php
@@ -138,6 +138,16 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
             })
             ->end()
 
+            ->beginCommand('clear-cache')
+            ->setDescription('Clears the Hubkit cache directory. Run this command to free-up space or resolve recurring errors')
+            ->setHandler(function () {
+                return new Handler\ClearCacheHandler(
+                    $this->container['style'],
+                    $this->container['filesystem'],
+                );
+            })
+            ->end()
+
             ->beginCommand('repo-create')
             ->setDescription('Create a new empty GitHub repository. Wiki and Downloads are disabled by default')
             ->addArgument('full-name', Argument::REQUIRED, 'The user (org) and repository name. Eg. acme/my-repo')
@@ -159,7 +169,7 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
             ->setHandler(function () {
                 return new Handler\SplitRepoHandler(
                     $this->container['style'],
-                    $this->container['splitsh_git'],
+                    $this->container['branch_splitsh_git'],
                     $this->container['git'],
                     $this->container['github'],
                     $this->container['config']
@@ -229,6 +239,7 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
             ->addOption('security', null, Option::BOOLEAN, 'Merge pull request as a security patch')
             ->addOption('squash', null, Option::BOOLEAN, 'Squash the pull request before merging')
             ->addOption('no-pull', null, Option::BOOLEAN, 'Skip pulling changes to your local branch')
+            ->addOption('no-split', null, Option::BOOLEAN, 'Skip splitting of monolith repository')
             ->addOption('no-cleanup', null, Option::BOOLEAN, 'Skip clean-up of feature branch (if present)')
             ->addOption('pat', null, Option::OPTIONAL_VALUE | Option::STRING, 'Thank you message, @author will be replaced with pr author(s)', 'Thank you @author')
             ->addOption('no-pat', null, Option::NO_VALUE | Option::BOOLEAN, 'Skip thank you message, cannot be used in combination with --pat')
@@ -240,7 +251,7 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
                     new BranchAliasResolver($this->container['style'], $this->container['git'], getcwd()),
                     new SingleLineChoiceQuestionHelper(),
                     $this->container['config'],
-                    $this->container['splitsh_git']
+                    $this->container['branch_splitsh_git']
                 );
             })
             ->end()
@@ -299,7 +310,7 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
                     $this->container['github'],
                     $this->container['process'],
                     $this->container['config'],
-                    $this->container['splitsh_git']
+                    $this->container['branch_splitsh_git']
                 );
             })
             ->end()
@@ -319,7 +330,7 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
                     $this->container['process'],
                     $this->container['editor'],
                     $this->container['config'],
-                    $this->container['splitsh_git'],
+                    $this->container['branch_splitsh_git'],
                     $this->container['release_hooks']
                 );
             })

--- a/src/Container.php
+++ b/src/Container.php
@@ -63,6 +63,14 @@ class Container extends \Pimple\Container implements ContainerInterface
             (new ExecutableFinder())->find('splitsh-lite')
         );
 
+        $this['branch_splitsh_git'] = static fn (self $container) => new Service\BranchSplitsh(
+            $container['splitsh_git'],
+            $container['github'],
+            $container['config'],
+            $container['style'],
+            $container['git'],
+        );
+
         $this['filesystem'] = static fn () => new Service\Filesystem();
 
         $this['editor'] = static fn (self $container) => new Service\Editor($container['process'], $container['filesystem']);

--- a/src/Container.php
+++ b/src/Container.php
@@ -51,17 +51,17 @@ class Container extends \Pimple\Container implements ContainerInterface
 
         $this['git.config'] = static fn (self $container) => new Service\Git\GitConfig($container['process'], $container['style']);
 
-        $this['git.file_reader'] = static fn (self $container) => new Service\Git\GitFileReader($container['git.branch'], $container['git.config'], $container['process'], $container['filesystem']);
+        $this['git.temp_repository'] = static fn (self $container) => new Service\Git\GitTempRepository($container['process'], $container['filesystem']);
 
-        $this['splitsh_git'] = static function (self $container) {
-            return new Service\SplitshGit(
-                $container['git'],
-                $container['process'],
-                $container['filesystem'],
-                $container['logger'],
-                (new ExecutableFinder())->find('splitsh-lite')
-            );
-        };
+        $this['git.file_reader'] = static fn (self $container) => new Service\Git\GitFileReader($container['git.branch'], $container['git.config'], $container['process'], $container['git.temp_repository']);
+
+        $this['splitsh_git'] = static fn (self $container) => new Service\SplitshGit(
+            $container['git'],
+            $container['process'],
+            $container['logger'],
+            $container['git.temp_repository'],
+            (new ExecutableFinder())->find('splitsh-lite')
+        );
 
         $this['filesystem'] = static fn () => new Service\Filesystem();
 

--- a/src/Service/BranchSplitsh.php
+++ b/src/Service/BranchSplitsh.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HubKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Service;
+
+use HubKit\BranchConfig;
+use HubKit\Config;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * BranchSplitsh wraps around the SplitshGit service to the
+ * branch configuration for performing operations.
+ */
+class BranchSplitsh
+{
+    public function __construct(
+        private SplitshGit $splitshGit,
+        private GitHub $github,
+        private Config $config,
+        private SymfonyStyle $style,
+        private Git $git
+    ) {
+    }
+
+    /**
+     * Split the prefix directory into another repository.
+     *
+     * Target configuration and whether this branch should be split et all
+     * is automatically resolved from the configuration.
+     *
+     * @param string $branch The source branch to split from
+     * @param string $prefix Directory prefix, relative to the root directory
+     *
+     * @return array{0: string, 1: string, 2: string}|null Same as {@link SplitshGit::splitTo}
+     */
+    public function splitAtPrefix(string $branch, string $prefix): ?array
+    {
+        $config = $this->getConfigForPrefix($branch, $prefix);
+        $this->style->writeln(sprintf('<fg=default;bg=default> Splitting %s to %s</>', $prefix, $config['url']));
+
+        return $this->splitshGit->splitTo($branch, $prefix, $config['url']);
+    }
+
+    private function getConfigForPrefix(string $branch, string $prefix): mixed
+    {
+        $this->git->ensureBranchInSync('upstream', $branch);
+        $this->splitshGit->checkPrecondition();
+
+        $branchConfig = $this->getBranchConfig($branch);
+
+        if (! isset($branchConfig->config['split'][$prefix])) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Unable to split repository at prefix: No entry found for "[%s][split][%s]".',
+                    implode('][', $branchConfig->configPath),
+                    $prefix
+                )
+            );
+        }
+
+        $config = $branchConfig->config['split'][$prefix];
+
+        if ($config['url'] === false) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Unable to split repository at prefix: Entry is disabled for "[%s][split][%s]".',
+                    implode('][', $branchConfig->configPath),
+                    $prefix
+                )
+            );
+        }
+
+        return $config;
+    }
+
+    private function getBranchConfig(string $branch): BranchConfig
+    {
+        $branchConfig = $this->config->getBranchConfig($this->github->getHostname(), $this->github->getOrganization() . '/' . $this->github->getRepository(), $branch);
+
+        if (empty($branchConfig->config['split'])) {
+            $this->style->text(sprintf('No repository-split targets were found in config "[%s]".', implode('][', $branchConfig->configPath)));
+        } elseif ($branch !== $branchConfig->configName) {
+            $this->style->text(sprintf('Repository-split configuration for branch <fg=yellow>%s</> resolved from <fg=yellow>%s</>.', $branch, $branchConfig->configName));
+        }
+
+        return $branchConfig;
+    }
+
+    /**
+     * Split all from the branch to their destinations, unlike splitTo()
+     * this will pass when no destinations are found.
+     *
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function splitBranch(string $branch): array
+    {
+        $splits = $this->getSplit($this->getBranchConfig($branch));
+
+        if (\count($splits) === 0) {
+            return [];
+        }
+
+        $this->git->ensureBranchInSync('upstream', $branch);
+        $this->splitshGit->checkPrecondition();
+
+        $results = [];
+
+        $this->style->section(sprintf('Splitting from %s to %d destinations', $branch, \count($splits)));
+
+        foreach ($splits as $prefix => $config) {
+            $split = $this->splitshGit->splitTo($branch, $prefix, $config['url']);
+
+            if ($split === null) {
+                continue;
+            }
+
+            $results[$prefix] = $split;
+            $this->style->writeln(sprintf('<fg=default;bg=default> Splitting %s to %s</>', $prefix, $config['url']));
+        }
+
+        return $results;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function getSplit(BranchConfig $branchConfig): array
+    {
+        return array_filter($branchConfig->config['split'] ?? [], static fn ($v): bool => $v['url'] !== false);
+    }
+
+    /**
+     * Synchronize the source tag to split repositories.
+     *
+     * This method re-uses the information provided by splitTo().
+     * Existing tags are silently ignored.
+     *
+     * @param string $versionStr Version (without prefix) for the tag name
+     *
+     *                           @return int The number of tags synchronized
+     */
+    public function syncTags(string $branch, string $versionStr): int
+    {
+        $splits = $this->splitBranch($branch);
+
+        // Check if there are any splits to prevent duplicate messages.
+        if (\count($splits) === 0) {
+            return 0;
+        }
+
+        $branchConfig = $this->getBranchConfig($branch);
+        $count = 0;
+
+        foreach ($splits as $prefix => $split) {
+            if (($branchConfig->config['split'][$prefix]['sync-tags'] ?? $branchConfig->config['sync-tags'] ?? true) === false) {
+                $this->style->writeln(sprintf('<fg=default;bg=default> Repository-split tag synchronizing is disabled for directory %s</>', $prefix));
+
+                continue;
+            }
+
+            $this->splitshGit->syncTag($versionStr, $split[1], $branch, $split[0]);
+            ++$count;
+        }
+
+        return $count;
+    }
+
+    public function drySplitAtPrefix(string $branch, string $prefix): void
+    {
+        $config = $this->getConfigForPrefix($branch, $prefix);
+
+        $this->style->writeln(sprintf('<fg=default;bg=default> [DRY-RUN] Splitting %s to %s</>', $prefix, $config['url']));
+    }
+
+    /**
+     * @return int The number of splits
+     */
+    public function drySplitBranch(string $branch): int
+    {
+        $splits = $this->getSplit($this->getBranchConfig($branch));
+
+        if (\count($splits) === 0) {
+            return 0;
+        }
+
+        $this->splitshGit->checkPrecondition();
+
+        $this->style->section(sprintf('Would be splitting branch %s to %d destinations', $branch, \count($splits)));
+
+        foreach ($splits as $prefix => $config) {
+            $this->style->writeln(sprintf('<fg=default;bg=default> [DRY-RUN] Splitting %s to %s</>', $prefix, $config['url']));
+        }
+
+        return \count($splits);
+    }
+}

--- a/src/Service/Filesystem.php
+++ b/src/Service/Filesystem.php
@@ -23,8 +23,10 @@ class Filesystem
 
     public function __construct(?string $tempdir = null, ?SfFilesystem $sfFilesystem = null)
     {
-        $this->tempdir = $tempdir ?: sys_get_temp_dir();
         $this->fs = $sfFilesystem ?? new SfFilesystem();
+        $this->tempdir = ($tempdir ?: sys_get_temp_dir()) . \DIRECTORY_SEPARATOR . 'hubkit';
+
+        $this->fs->mkdir($this->tempdir);
     }
 
     /**
@@ -36,10 +38,7 @@ class Filesystem
      */
     public function newTempFilename(string $content = null): string
     {
-        $dir = $this->tempdir . \DIRECTORY_SEPARATOR . 'hubkit';
-        $this->fs->mkdir($dir);
-
-        $tmpName = tempnam($dir, '');
+        $tmpName = tempnam($this->tempdir, '');
         $this->tempFilenames[] = $tmpName;
 
         if ($content !== null) {
@@ -70,7 +69,7 @@ class Filesystem
      */
     public function tempDirectory(string $name, bool $clearExisting = true, ?bool &$exists = null): string
     {
-        $tmpName = $this->tempdir . \DIRECTORY_SEPARATOR . 'hubkit' . \DIRECTORY_SEPARATOR . 'temp' . \DIRECTORY_SEPARATOR . $name;
+        $tmpName = $this->tempdir . \DIRECTORY_SEPARATOR . 'temp' . \DIRECTORY_SEPARATOR . $name;
         $exists = $this->fs->exists($tmpName);
 
         if ($clearExisting && $exists) {
@@ -92,7 +91,7 @@ class Filesystem
      */
     public function storageTempDirectory(string $name, bool $clearExisting = true, ?bool &$exists = null): string
     {
-        $tmpName = $this->tempdir . \DIRECTORY_SEPARATOR . 'hubkit' . \DIRECTORY_SEPARATOR . 'stor' . \DIRECTORY_SEPARATOR . $name;
+        $tmpName = $this->tempdir . \DIRECTORY_SEPARATOR . 'stor' . \DIRECTORY_SEPARATOR . $name;
         $exists = $this->fs->exists($tmpName);
 
         if ($clearExisting && $exists) {
@@ -114,6 +113,11 @@ class Filesystem
         $this->tempFilenames = [];
     }
 
+    public function clearTempFolder(): void
+    {
+        $this->fs->remove($this->tempdir);
+    }
+
     public function getFilesystem(): SfFilesystem
     {
         return $this->fs;
@@ -127,5 +131,10 @@ class Filesystem
     public function getCwd(): string | false
     {
         return getcwd();
+    }
+
+    public function getTempdir(): string
+    {
+        return $this->tempdir;
     }
 }

--- a/src/Service/Git/GitFileReader.php
+++ b/src/Service/Git/GitFileReader.php
@@ -81,7 +81,7 @@ class GitFileReader
             throw GitFileNotFound::atBranch($branch, $path);
         }
 
-        return $this->gitTempRepository->getLocal(mb_substr($this->gitBranch->getGitDirectory(), 0, -5), $branch ). \DIRECTORY_SEPARATOR . $path;
+        return $this->gitTempRepository->getLocal(mb_substr($this->gitBranch->getGitDirectory(), 0, -5), $branch) . \DIRECTORY_SEPARATOR . $path;
     }
 
     /**
@@ -115,6 +115,6 @@ class GitFileReader
             throw GitFileNotFound::atRemote($remote, $branch, $path);
         }
 
-        return $this->gitTempRepository->getRemote($this->gitConfig->getLocal('remote.' . $remote . '.url'), $branch) . DIRECTORY_SEPARATOR . $path;
+        return $this->gitTempRepository->getRemote($this->gitConfig->getLocal('remote.' . $remote . '.url'), $branch) . \DIRECTORY_SEPARATOR . $path;
     }
 }

--- a/src/Service/Git/GitFileReader.php
+++ b/src/Service/Git/GitFileReader.php
@@ -15,9 +15,7 @@ namespace HubKit\Service\Git;
 
 use HubKit\Exception\GitFileNotFound;
 use HubKit\Service\CliProcess;
-use HubKit\Service\Filesystem;
 use HubKit\StringUtil;
-use Symfony\Component\Process\Process;
 
 /**
  * The GitFileReader allows get access to files in another branch.
@@ -31,7 +29,7 @@ class GitFileReader
         private GitBranch $gitBranch,
         private GitConfig $gitConfig,
         private CliProcess $process,
-        private Filesystem $filesystem
+        private GitTempRepository $gitTempRepository
     ) {
     }
 
@@ -83,23 +81,7 @@ class GitFileReader
             throw GitFileNotFound::atBranch($branch, $path);
         }
 
-        return $this->getFileAtRepository('file://' . mb_substr($this->gitBranch->getGitDirectory(), 0, -5), $branch, $path);
-    }
-
-    private function getFileAtRepository(string $repositoryUrl, string $branch, string $path): string
-    {
-        $tempdir = $this->filesystem->storageTempDirectory('repo_' . sha1($repositoryUrl), false, $exists);
-
-        if (! $exists) {
-            $this->process->mustRun(['git', 'clone', '--no-checkout', '--no-tags', '--origin', 'origin', $repositoryUrl, $tempdir]);
-        } else {
-            $this->process->mustRun(new Process(['git', 'fetch', '--no-tags', 'origin'], $tempdir));
-        }
-
-        $this->process->mustRun(new Process(['git', 'reset', '--hard'], $tempdir)); // Ensure the repository state is clean.
-        $this->process->mustRun(new Process(['git', 'checkout', 'remotes/origin/' . $branch], $tempdir));
-
-        return $tempdir . \DIRECTORY_SEPARATOR . $path;
+        return $this->gitTempRepository->getLocal(mb_substr($this->gitBranch->getGitDirectory(), 0, -5), $branch ). \DIRECTORY_SEPARATOR . $path;
     }
 
     /**
@@ -133,6 +115,6 @@ class GitFileReader
             throw GitFileNotFound::atRemote($remote, $branch, $path);
         }
 
-        return $this->getFileAtRepository($this->gitConfig->getLocal('remote.' . $remote . '.url'), $branch, $path);
+        return $this->gitTempRepository->getRemote($this->gitConfig->getLocal('remote.' . $remote . '.url'), $branch) . DIRECTORY_SEPARATOR . $path;
     }
 }

--- a/src/Service/Git/GitTempRepository.php
+++ b/src/Service/Git/GitTempRepository.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HubKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Service\Git;
+
+use HubKit\Service\CliProcess;
+use HubKit\Service\Filesystem;
+use HubKit\StringUtil;
+use Symfony\Component\Process\Process;
+
+/**
+ * The GitTempRepository creates/provides a temporary Git working directory for a repository.
+ */
+class GitTempRepository
+{
+    public function __construct(
+        private CliProcess $process,
+        private Filesystem $filesystem
+    ) {
+    }
+
+    public function getLocal(string $directory, string $branch = null): string
+    {
+        return $this->getRemote('file://' . $directory, $branch);
+    }
+
+    public function getRemote(string $repositoryUrl, ?string $branch = null): string
+    {
+        $tempdir = $this->filesystem->storageTempDirectory('repo_' . sha1($repositoryUrl), false, $exists);
+
+        if (! $exists) {
+            $this->process->mustRun(['git', 'clone', '--no-checkout', '--origin', 'origin', $repositoryUrl, $tempdir]);
+        } else {
+            $this->process->mustRun(new Process(['git', 'fetch', '--tags', 'origin'], $tempdir));
+            $this->process->mustRun(new Process(['git', 'reset', '--hard'], $tempdir)); // Ensure the repository state is clean.
+        }
+
+        if ($branch !== null) {
+            $this->checkout($tempdir, $branch);
+        }
+
+        return $tempdir;
+    }
+
+    private function checkout(string $directory, string $branchName): void
+    {
+        if ($this->branchExists($directory, $branchName)) {
+            $this->process->mustRun(new Process(['git', 'checkout', $branchName], $directory));
+            $this->process->mustRun(new Process(['git', 'reset', '--hard', 'remotes/origin/' . $branchName], $directory));
+
+            return;
+        }
+
+        $this->process->mustRun(new Process(['git', 'checkout', 'remotes/origin/' . $branchName, '-b', $branchName], $directory));
+    }
+
+    private function branchExists(string $directory, string $branch): bool
+    {
+        $branches = StringUtil::splitLines(
+            $this->process->mustRun(new Process(['git', 'for-each-ref', '--format', '%(refname:short)', 'refs/heads/'], $directory))->getOutput()
+        );
+
+        return \in_array($branch, $branches, true);
+    }
+}

--- a/src/Service/SplitshGit.php
+++ b/src/Service/SplitshGit.php
@@ -43,13 +43,14 @@ class SplitshGit
      * @param string $prefix       Directory prefix, relative to the root directory
      * @param string $url          Git supported URL for pushing the commits
      *
-     * @return array<string, array{0: string, 1: string}>|null Information of the split ['repository-location' => ['commit-hash', 'url', 'commits count']]
-     *                                                         or null when prefix doesn't exist
+     * @return array{0: string, 1: string, 2: string}|null Information of the split ['commit-hash', 'url', 'repository-location']]
+     *                                                     or null when prefix doesn't exist
      */
     public function splitTo(string $targetBranch, string $prefix, string $url): ?array
     {
         if (! file_exists(getcwd() . '/' . $prefix) || ! is_dir(getcwd() . '/' . $prefix)) {
-            $this->logger->warning('Prefix directory "{prefix}" for "{url}" does not exist in the local repository', ['prefix' => $prefix, 'url' => $url]);
+            $this->logger->warning('Prefix directory "{prefix}" for "{url}" does not exist in the local repository.', ['prefix' => $prefix, 'url' => $url]);
+            $this->logger->warning('The behaviour for missing directories will change in Hubkit v2.0 and this warning will produce an fatal error. Set the split for this destination to "false" instead');
 
             return null;
         }
@@ -65,7 +66,7 @@ class SplitshGit
 
         $this->process->mustRun(new Process(['git', 'push', 'origin', $targetBranch . ':refs/heads/' . $targetBranch], $tempDir));
 
-        return [$tempDir => [$sha, $url]];
+        return [$sha, $url, $tempDir];
     }
 
     /**

--- a/tests/Functional/Service/Git/GitFileReaderTest.php
+++ b/tests/Functional/Service/Git/GitFileReaderTest.php
@@ -19,6 +19,7 @@ use HubKit\Service\Filesystem;
 use HubKit\Service\Git\GitBranch;
 use HubKit\Service\Git\GitConfig;
 use HubKit\Service\Git\GitFileReader;
+use HubKit\Service\Git\GitTempRepository;
 use HubKit\Tests\Functional\GitTesterTrait;
 use HubKit\Tests\Functional\TestCliProcess;
 use HubKit\Tests\Handler\SymfonyStyleTrait;
@@ -39,6 +40,7 @@ final class GitFileReaderTest extends TestCase
 
     private Filesystem $filesystem;
     private TestCliProcess $cliProcess;
+    private GitTempRepository $gitTempRepository;
     private StyleInterface $style;
 
     /** @before */
@@ -70,9 +72,12 @@ final class GitFileReaderTest extends TestCase
         $this->commitFileToRepository('foo3.txt', $this->rootRepository, 'foo3.txt in master on root'); // File is added after pull and therefor shouldn't exist or second
 
         $this->cwd = $this->rootRepository;
+
         $this->filesystem ??= new Filesystem();
         $this->cliProcess = $this->getProcessService($this->rootRepository);
         $this->cliProcess->ignoreCwdChangeWhen(static fn (string $val): bool => str_contains($val, '/hubkit/stor/repo_'));
+
+        $this->gitTempRepository ??= new GitTempRepository($this->cliProcess, $this->filesystem);
     }
 
     /** @after */
@@ -142,7 +147,7 @@ final class GitFileReaderTest extends TestCase
             },
             new GitConfig($this->cliProcess, $style),
             $this->cliProcess,
-            $this->filesystem
+            $this->gitTempRepository
         );
     }
 

--- a/tests/Service/BranchSplitshTest.php
+++ b/tests/Service/BranchSplitshTest.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HubKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Tests\Service;
+
+use HubKit\Config;
+use HubKit\Service\BranchSplitsh;
+use HubKit\Service\Git;
+use HubKit\Service\GitHub;
+use HubKit\Service\SplitshGit;
+use HubKit\Tests\Handler\SymfonyStyleTrait;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+
+/**
+ * @internal
+ */
+final class BranchSplitshTest extends TestCase
+{
+    use ProphecyTrait;
+    use SymfonyStyleTrait;
+
+    /** @var Git&ObjectProphecy */
+    private $git;
+    /** @var GitHub&ObjectProphecy */
+    private $github;
+    private Config $config;
+    /** @var SplitshGit&ObjectProphecy */
+    private $splitshGit;
+
+    /** @before */
+    public function setUpServices(): void
+    {
+        $this->git = $this->prophesize(Git::class);
+        $this->git->getActiveBranchName()->willReturn('master');
+
+        $this->github = $this->prophesize(GitHub::class);
+        $this->github->getHostname()->willReturn('github.com');
+        $this->github->getOrganization()->willReturn('hubkit-sandbox');
+        $this->github->getRepository()->willReturn('empire');
+
+        $this->config = new Config([
+            'schema_version' => 2,
+            'github' => [
+                'github.com' => [
+                    'username' => 'sstok',
+                    'api_token' => 'CHANGE-ME',
+                ],
+            ],
+            'repositories' => [
+                'github.com' => [
+                    'repos' => [
+                        'hubkit-sandbox/empire' => [
+                            'branches' => [
+                                ':default' => [
+                                    'sync-tags' => false,
+                                    'split' => [
+                                        'src/Module/CoreModule' => ['url' => 'git@github.com:hubkit-sandbox/core-module.git', 'sync-tags' => null],
+                                        'src/Module/WebhostingModule' => ['url' => 'git@github.com:hubkit-sandbox/webhosting-module.git', 'sync-tags' => true],
+                                    ],
+                                ],
+                                'master' => [
+                                    'sync-tags' => true,
+                                    'split' => [
+                                        'docs' => ['url' => 'git@github.com:hubkit-sandbox/docs.git'],
+                                        'noop' => ['url' => 'git@github.com:hubkit-sandbox/noop.git', 'sync-tags' => false],
+                                    ],
+                                ],
+                                '2.x' => [
+                                    'sync-tags' => true,
+                                    'split' => [
+                                        'lobster' => ['url' => 'git@github.com:hubkit-sandbox/pinchy.git'],
+                                    ],
+                                ],
+                                '3.x' => [
+                                    'sync-tags' => true,
+                                    'ignore-default' => true,
+                                    'split' => [],
+                                ],
+                                '6.x' => [
+                                    'sync-tags' => true,
+                                    'ignore-default' => true,
+                                    'split' => [
+                                        'src/Module/WebhostingModule' => ['url' => false, 'sync-tags' => true],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'hubkit-sandbox/website' => [
+                            'branches' => [
+                                '1.0' => [
+                                    'sync-tags' => false,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            '_local' => [
+                'branches' => [
+                    'v1.1' => [
+                        'sync-tags' => true,
+                        'split' => [
+                            'src/Module/CoreModule' => ['url' => 'git@github.com:hubkit-sandbox/core-module.git'],
+                            'src/Module/WebhostingModule' => ['url' => 'git@github.com:hubkit-sandbox/webhosting-module.git'],
+                            'docs' => ['url' => 'git@github.com:hubkit-sandbox/docs2.git'],
+                            'noop' => ['url' => 'git@github.com:hubkit-sandbox/noop2.git'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->splitshGit = $this->prophesize(SplitshGit::class);
+        $this->splitshGit->checkPrecondition()->shouldBeCalled();
+    }
+
+    /** @test */
+    public function splits_prefix_to_destinations_with_no_explicit_config(): void
+    {
+        $this->git->ensureBranchInSync('upstream', '4.0')->shouldBeCalled();
+        $this->expectGitSplit('src/Module/CoreModule', 'git@github.com:hubkit-sandbox/core-module.git', 'cc1', '4.0');
+
+        self::assertEquals(
+            [
+                '/tmp/hubkit/stor/src/Module/CoreModule' => ['cc1', 'git@github.com:hubkit-sandbox/core-module.git'],
+            ],
+            $this->getBranchSplitsh()->splitAtPrefix('4.0', 'src/Module/CoreModule')
+        );
+
+        $this->assertOutputMatches([
+            'Repository-split configuration for branch 4.0 resolved from :default.',
+            'Splitting src/Module/CoreModule to git@github.com:hubkit-sandbox/core-module.git',
+        ]);
+    }
+
+    private function expectGitSplit(string $prefix, string $url, string $sha, string $branch = 'master', bool $success = true): void
+    {
+        $this->splitshGit->splitTo($branch, $prefix, $url)->willReturn($success ? ['/tmp/hubkit/stor/' . $prefix => [$sha, $url]] : null);
+    }
+
+    private function getBranchSplitsh(): BranchSplitsh
+    {
+        return new BranchSplitsh(
+            $this->splitshGit->reveal(),
+            $this->github->reveal(),
+            $this->config,
+            $this->createStyle(),
+            $this->git->reveal()
+        );
+    }
+
+    /** @test */
+    public function splits_prefix_to_destinations_with_explicit_config(): void
+    {
+        $this->git->ensureBranchInSync('upstream', '2.1')->shouldBeCalled();
+        $this->expectGitSplit('lobster', 'git@github.com:hubkit-sandbox/pinchy.git', 'cc1', '2.1');
+
+        self::assertEquals(
+            [
+                '/tmp/hubkit/stor/lobster' => ['cc1', 'git@github.com:hubkit-sandbox/pinchy.git'],
+            ],
+            $this->getBranchSplitsh()->splitAtPrefix('2.1', 'lobster')
+        );
+
+        $this->assertOutputMatches([
+            'Repository-split configuration for branch 2.1 resolved from 2.x.',
+            'Splitting lobster to git@github.com:hubkit-sandbox/pinchy.git',
+        ]);
+    }
+
+    /** @test */
+    public function split_prefix_to_destinations_fails_for_missing_prefix_configuration(): void
+    {
+        $this->git->ensureBranchInSync('upstream', '4.1')->shouldBeCalled();
+
+        $this->expectExceptionObject(new \InvalidArgumentException(
+            'Unable to split repository at prefix: No entry found for "[repositories][github.com][repos][hubkit-sandbox/empire][branches][:default][split][pinchy]".'
+        ));
+
+        $this->getBranchSplitsh()->splitAtPrefix('4.1', 'pinchy');
+    }
+
+    /** @test */
+    public function splits_branch_to_destinations_with_no_explicit_config(): void
+    {
+        $this->git->ensureBranchInSync('upstream', '4.0')->shouldBeCalled();
+        $this->expectGitSplit('src/Module/CoreModule', 'git@github.com:hubkit-sandbox/core-module.git', 'cc1', '4.0');
+        $this->expectGitSplit('src/Module/WebhostingModule', 'git@github.com:hubkit-sandbox/webhosting-module.git', 'cc2', '4.0');
+
+        self::assertEquals(
+            [
+                'src/Module/CoreModule' => ['/tmp/hubkit/stor/src/Module/CoreModule' => ['cc1', 'git@github.com:hubkit-sandbox/core-module.git']],
+                'src/Module/WebhostingModule' => ['/tmp/hubkit/stor/src/Module/WebhostingModule' => ['cc2', 'git@github.com:hubkit-sandbox/webhosting-module.git']],
+            ],
+            $this->getBranchSplitsh()->splitBranch('4.0')
+        );
+
+        $this->assertOutputMatches([
+            'Repository-split configuration for branch 4.0 resolved from :default.',
+            'Splitting from 4.0 to 2 destinations',
+            'Splitting src/Module/CoreModule to git@github.com:hubkit-sandbox/core-module.git',
+            'Splitting src/Module/WebhostingModule to git@github.com:hubkit-sandbox/webhosting-module.git',
+        ]);
+    }
+
+    /** @test */
+    public function splits_branch_to_destinations_with_explicit_config(): void
+    {
+        $this->git->ensureBranchInSync('upstream', '2.1')->shouldBeCalled();
+        $this->expectGitSplit('src/Module/CoreModule', 'git@github.com:hubkit-sandbox/core-module.git', 'cc1', '2.1');
+        $this->expectGitSplit('src/Module/WebhostingModule', 'git@github.com:hubkit-sandbox/webhosting-module.git', 'cc2', '2.1');
+        $this->expectGitSplit('lobster', 'git@github.com:hubkit-sandbox/pinchy.git', 'cc3', '2.1');
+
+        self::assertEquals(
+            [
+                'src/Module/CoreModule' => ['/tmp/hubkit/stor/src/Module/CoreModule' => ['cc1', 'git@github.com:hubkit-sandbox/core-module.git']],
+                'src/Module/WebhostingModule' => ['/tmp/hubkit/stor/src/Module/WebhostingModule' => ['cc2', 'git@github.com:hubkit-sandbox/webhosting-module.git']],
+                'lobster' => ['/tmp/hubkit/stor/lobster' => ['cc3', 'git@github.com:hubkit-sandbox/pinchy.git']],
+            ],
+            $this->getBranchSplitsh()->splitBranch('2.1')
+        );
+
+        $this->assertOutputMatches([
+            'Repository-split configuration for branch 2.1 resolved from 2.x.',
+            'Splitting from 2.1 to 3 destinations',
+            'Splitting src/Module/CoreModule to git@github.com:hubkit-sandbox/core-module.git',
+            'Splitting src/Module/WebhostingModule to git@github.com:hubkit-sandbox/webhosting-module.git',
+            'Splitting lobster to git@github.com:hubkit-sandbox/pinchy.git',
+        ]);
+    }
+
+    /** @test */
+    public function splits_branch_to_destinations_with_explicit_config2(): void
+    {
+        $this->git->ensureBranchInSync('upstream', 'master')->shouldBeCalled();
+        $this->expectGitSplit('src/Module/CoreModule', 'git@github.com:hubkit-sandbox/core-module.git', 'cc1');
+        $this->expectGitSplit('src/Module/WebhostingModule', 'git@github.com:hubkit-sandbox/webhosting-module.git', 'cc2');
+        $this->expectGitSplit('docs', 'git@github.com:hubkit-sandbox/docs.git', 'cc3');
+        $this->expectGitSplit('noop', 'git@github.com:hubkit-sandbox/noop.git', 'cc4');
+
+        self::assertEquals(
+            [
+                'src/Module/CoreModule' => ['/tmp/hubkit/stor/src/Module/CoreModule' => ['cc1', 'git@github.com:hubkit-sandbox/core-module.git']],
+                'src/Module/WebhostingModule' => ['/tmp/hubkit/stor/src/Module/WebhostingModule' => ['cc2', 'git@github.com:hubkit-sandbox/webhosting-module.git']],
+                'docs' => ['/tmp/hubkit/stor/docs' => ['cc3', 'git@github.com:hubkit-sandbox/docs.git']],
+                'noop' => ['/tmp/hubkit/stor/noop' => ['cc4', 'git@github.com:hubkit-sandbox/noop.git']],
+            ],
+            $this->getBranchSplitsh()->splitBranch('master')
+        );
+
+        $this->assertOutputMatches([
+            'Splitting from master to 4 destinations',
+            'Splitting src/Module/CoreModule to git@github.com:hubkit-sandbox/core-module.git',
+            'Splitting src/Module/WebhostingModule to git@github.com:hubkit-sandbox/webhosting-module.git',
+            'Splitting docs to git@github.com:hubkit-sandbox/docs.git',
+            'Splitting noop to git@github.com:hubkit-sandbox/noop.git',
+        ]);
+
+        // No special configuration resolved, so no need to show this information
+        $this->assertOutputNotMatches('Repository-split configuration for branch master');
+    }
+
+    /** @test */
+    public function splits_branch_to_destinations_is_ignored_when_no_splits_are_configured(): void
+    {
+        $this->expectNoSplitPerformed();
+        $this->splitshGit->checkPrecondition()->shouldNotBeCalled();
+
+        self::assertEquals(
+            [],
+            $this->getBranchSplitsh()->splitBranch('3.2')
+        );
+
+        $this->assertOutputMatches('No repository-split targets were found in config "[repositories][github.com][repos][hubkit-sandbox/empire][branches][3.x]".');
+        $this->assertOutputNotMatches('Splitting from branch 3.2 to');
+    }
+
+    private function expectNoSplitPerformed(): void
+    {
+        $this->splitshGit->splitTo(Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
+    }
+
+    // Dry-run
+
+    /** @test */
+    public function dry_splits_prefix_to_destinations_with_no_explicit_config(): void
+    {
+        $this->git->ensureBranchInSync('upstream', '4.0')->shouldBeCalled();
+        $this->expectNoSplitPerformed();
+
+        $this->getBranchSplitsh()->drySplitAtPrefix('4.0', 'src/Module/CoreModule');
+
+        $this->assertOutputMatches([
+            'Repository-split configuration for branch 4.0 resolved from :default.',
+            '[DRY-RUN] Splitting src/Module/CoreModule to git@github.com:hubkit-sandbox/core-module.git',
+        ]);
+    }
+
+    /** @test */
+    public function dry_splits_prefix_to_destinations_with_explicit_config(): void
+    {
+        $this->git->ensureBranchInSync('upstream', '2.1')->shouldBeCalled();
+        $this->expectNoSplitPerformed();
+
+        $this->getBranchSplitsh()->drySplitAtPrefix('2.1', 'lobster');
+
+        $this->assertOutputMatches([
+            'Repository-split configuration for branch 2.1 resolved from 2.x.',
+            '[DRY-RUN] Splitting lobster to git@github.com:hubkit-sandbox/pinchy.git',
+        ]);
+    }
+
+    /** @test */
+    public function dry_split_prefix_to_destinations_fails_for_missing_prefix_configuration(): void
+    {
+        $this->git->ensureBranchInSync('upstream', '2.1')->shouldBeCalled();
+
+        $this->expectExceptionObject(new \InvalidArgumentException(
+            'Unable to split repository at prefix: No entry found for "[repositories][github.com][repos][hubkit-sandbox/empire][branches][2.x][split][pinchy]".'
+        ));
+
+        $this->getBranchSplitsh()->drySplitAtPrefix('2.1', 'pinchy');
+    }
+
+    /** @test */
+    public function dry_split_prefix_to_destinations_fails_for_disabled_prefix_configuration(): void
+    {
+        $this->git->ensureBranchInSync('upstream', '6.1')->shouldBeCalled();
+
+        $this->expectExceptionObject(new \InvalidArgumentException(
+            'Unable to split repository at prefix: Entry is disabled for "[repositories][github.com][repos][hubkit-sandbox/empire][branches][6.x][split][src/Module/WebhostingModule]".'
+        ));
+
+        $this->getBranchSplitsh()->drySplitAtPrefix('6.1', 'src/Module/WebhostingModule');
+    }
+
+    /** @test */
+    public function dry_splits_branch_to_destinations_with_no_explicit_config(): void
+    {
+        $this->expectNoSplitPerformed();
+
+        $this->getBranchSplitsh()->drySplitBranch('4.0');
+
+        $this->assertOutputMatches([
+            'Repository-split configuration for branch 4.0 resolved from :default.',
+            'Would be splitting branch 4.0 to 2 destinations',
+            '[DRY-RUN] Splitting src/Module/CoreModule to git@github.com:hubkit-sandbox/core-module.git',
+            '[DRY-RUN] Splitting src/Module/WebhostingModule to git@github.com:hubkit-sandbox/webhosting-module.git',
+        ]);
+    }
+
+    /** @test */
+    public function dry_splits_branch_to_destinations_with_explicit_config(): void
+    {
+        $this->expectNoSplitPerformed();
+
+        $this->getBranchSplitsh()->drySplitBranch('2.1');
+
+        $this->assertOutputMatches([
+            'Repository-split configuration for branch 2.1 resolved from 2.x.',
+            'Would be splitting branch 2.1 to 3 destinations',
+            '[DRY-RUN] Splitting src/Module/CoreModule to git@github.com:hubkit-sandbox/core-module.git',
+            '[DRY-RUN] Splitting src/Module/WebhostingModule to git@github.com:hubkit-sandbox/webhosting-module.git',
+            '[DRY-RUN] Splitting lobster to git@github.com:hubkit-sandbox/pinchy.git',
+        ]);
+    }
+}

--- a/tests/Service/SplitshGitTest.php
+++ b/tests/Service/SplitshGitTest.php
@@ -55,7 +55,7 @@ final class SplitshGitTest extends TestCase
             $service = new SplitshGit($git, $cliProcess, $this->createMock(LoggerInterface::class), $gitTemp, self::SPLITSH_EXECUTABLE);
 
             self::assertEquals(
-                ['/tmp/hubkit/stor/_core' => ['2c00338aef823d0c0916fc1b59ef49d0bb76f02f', 'git@github.com:park-manager/core.git']],
+                ['2c00338aef823d0c0916fc1b59ef49d0bb76f02f', 'git@github.com:park-manager/core.git', '/tmp/hubkit/stor/_core'],
                 $service->splitTo('master', 'src/Bundle/CoreBundle', 'git@github.com:park-manager/core.git')
             );
         } finally {

--- a/tests/Service/SplitshGitTest.php
+++ b/tests/Service/SplitshGitTest.php
@@ -14,13 +14,12 @@ declare(strict_types=1);
 namespace HubKit\Tests\Service;
 
 use HubKit\Service\CliProcess;
-use HubKit\Service\Filesystem;
 use HubKit\Service\Git;
+use HubKit\Service\Git\GitTempRepository;
 use HubKit\Service\SplitshGit;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Filesystem\Filesystem as SfFilesystem;
 use Symfony\Component\Process\Process;
 
 /**
@@ -40,29 +39,23 @@ final class SplitshGitTest extends TestCase
         try {
             chdir(__DIR__ . '/Fixtures');
 
+            $gitTempProphecy = $this->prophesize(GitTempRepository::class);
+            $gitTempProphecy->getRemote('git@github.com:park-manager/core.git', 'master')->willReturn('/tmp/hubkit/stor/_core');
+            $gitTemp = $gitTempProphecy->reveal();
+
             $gitProphecy = $this->prophesize(Git::class);
-            $gitProphecy->isGitDir()->willReturn(true);
-            $gitProphecy->ensureRemoteExists('_core', 'git@github.com:park-manager/core.git')->shouldBeCalled();
-            $gitProphecy->pushToRemote('_core', '2c00338aef823d0c0916fc1b59ef49d0bb76f02f:refs/heads/master')->shouldBeCalled();
+            $gitProphecy->pushToRemote('file:///tmp/hubkit/stor/_core', '2c00338aef823d0c0916fc1b59ef49d0bb76f02f:refs/heads/master')->shouldBeCalled();
             $git = $gitProphecy->reveal();
 
-            $processProphecy = $this->prophesize(Process::class);
-            $processProphecy->getOutput()->willReturn('2c00338aef823d0c0916fc1b59ef49d0bb76f02f');
-            $processProphecy->getErrorOutput()->willReturn("\n5 commits created, 0 commits traversed, in 7ms");
-
             $processCliProphecy = $this->prophesize(CliProcess::class);
-            $processCliProphecy->mustRun([self::SPLITSH_EXECUTABLE, '--prefix', 'src/Bundle/CoreBundle'])->willReturn(
-                $processProphecy->reveal()
-            );
+            $processCliProphecy->mustRun([self::SPLITSH_EXECUTABLE, '--prefix', 'src/Bundle/CoreBundle'])->willReturn($this->getGitSplitShResult('2c00338aef823d0c0916fc1b59ef49d0bb76f02f'));
+            $processCliProphecy->mustRun(new Process(['git', 'push', 'origin', 'master:refs/heads/master'], '/tmp/hubkit/stor/_core'));
             $cliProcess = $processCliProphecy->reveal();
 
-            $filesystemProphecy = $this->prophesize(Filesystem::class);
-            $filesystem = $filesystemProphecy->reveal();
-
-            $service = new SplitshGit($git, $cliProcess, $filesystem, $this->createMock(LoggerInterface::class), self::SPLITSH_EXECUTABLE);
+            $service = new SplitshGit($git, $cliProcess, $this->createMock(LoggerInterface::class), $gitTemp, self::SPLITSH_EXECUTABLE);
 
             self::assertEquals(
-                ['_core' => ['2c00338aef823d0c0916fc1b59ef49d0bb76f02f', 'git@github.com:park-manager/core.git']],
+                ['/tmp/hubkit/stor/_core' => ['2c00338aef823d0c0916fc1b59ef49d0bb76f02f', 'git@github.com:park-manager/core.git']],
                 $service->splitTo('master', 'src/Bundle/CoreBundle', 'git@github.com:park-manager/core.git')
             );
         } finally {
@@ -71,43 +64,53 @@ final class SplitshGitTest extends TestCase
     }
 
     /** @test */
-    public function it_syncs_tag_into_targets(): void
+    public function it_syncs_tag_into_target(): void
     {
-        $gitProphecy = $this->prophesize(Git::class);
-        $gitProphecy->getGitConfig('remote._core.url')->willReturn('git@github.com:park-manager/core.git');
-        $gitProphecy->getGitConfig('remote._user.url')->willReturn('git@github.com:park-manager/user.git');
-        $gitProphecy->clone('git@github.com:park-manager/core.git', 'origin')->shouldBeCalledTimes(1);
-        $gitProphecy->clone('git@github.com:park-manager/user.git', 'origin')->shouldBeCalledTimes(1);
-        $gitProphecy->checkoutRemoteBranch('origin', '1.0')->shouldBeCalledTimes(2);
-
-        $git = $gitProphecy->reveal();
-
         $processCliProphecy = $this->prophesize(CliProcess::class);
-        $processCliProphecy->mustRun(['git', 'tag', 'v1.0.0', '2c00338aef823d0c0916fc1b59ef49d0bb76f02f', '-s', '-m', 'Release 1.0.0'])->shouldBeCalledTimes(1);
-        $processCliProphecy->mustRun(['git', 'tag', 'v1.0.0', '3eed8083737422fe9ac2da9f4348423089fceb7f', '-s', '-m', 'Release 1.0.0'])->shouldBeCalledTimes(1);
-        $processCliProphecy->run(['git', 'push', 'origin', 'v1.0.0'])->shouldBeCalledTimes(2);
+        $processCliProphecy->run(new Process(['git', 'tag', 'v1.0.0', '2c00338aef823d0c0916fc1b59ef49d0bb76f02f', '-s', '-m', 'Release 1.0.0'], '/tmp/hubkit/stor/_core'))->shouldBeCalledTimes(1);
+        $processCliProphecy->run(new Process(['git', 'push', 'origin', 'v1.0.0'], '/tmp/hubkit/stor/_core'));
         $cliProcess = $processCliProphecy->reveal();
 
-        $sfFilesystemProphecy = $this->prophesize(SfFilesystem::class);
-        $sfFilesystemProphecy->mkdir('/tmp/hubkit/split/_core')->shouldBeCalledTimes(1);
-        $sfFilesystemProphecy->mkdir('/tmp/hubkit/split/_user')->shouldBeCalledTimes(1);
+        $gitTempProphecy = $this->prophesize(GitTempRepository::class);
+        $gitTempProphecy->getRemote('git@github.com:park-manager/core.git', '1.0')->willReturn('/tmp/hubkit/stor/_core');
+        $gitTemp = $gitTempProphecy->reveal();
 
-        $filesystemProphecy = $this->prophesize(Filesystem::class);
-        $filesystemProphecy->tempDirectory('split')->willReturn('/tmp/hubkit/split');
-        $filesystemProphecy->chdir('/tmp/hubkit/split/_core')->willReturn(true)->shouldBeCalledTimes(1);
-        $filesystemProphecy->chdir('/tmp/hubkit/split/_user')->willReturn(true)->shouldBeCalledTimes(1);
-        $filesystemProphecy->chdir(getcwd())->willReturn(true)->shouldBeCalledTimes(1);
-        $filesystemProphecy->getFilesystem()->willReturn($sfFilesystemProphecy->reveal());
-        $filesystem = $filesystemProphecy->reveal();
+        $service = new SplitshGit($this->createMock(Git::class), $cliProcess, $this->createMock(LoggerInterface::class), $gitTemp, self::SPLITSH_EXECUTABLE);
 
-        $service = new SplitshGit($git, $cliProcess, $filesystem, $this->createMock(LoggerInterface::class), self::SPLITSH_EXECUTABLE);
+        $service->syncTag(
+            '1.0.0',
+            'git@github.com:park-manager/core.git',
+            '1.0',
+            '2c00338aef823d0c0916fc1b59ef49d0bb76f02f',
+        );
+    }
+
+    /** @test */
+    public function it_syncs_tag_into_targets(): void
+    {
+        $processCliProphecy = $this->prophesize(CliProcess::class);
+
+        $processCliProphecy->run(new Process(['git', 'tag', 'v1.0.0', '2c00338aef823d0c0916fc1b59ef49d0bb76f02f', '-s', '-m', 'Release 1.0.0'], '/tmp/hubkit/stor/_core'))->shouldBeCalledTimes(1);
+        $processCliProphecy->run(new Process(['git', 'push', 'origin', 'v1.0.0'], '/tmp/hubkit/stor/_core'));
+
+        $processCliProphecy->run(new Process(['git', 'tag', 'v1.0.0', '3eed8083737422fe9ac2da9f4348423089fceb7f', '-s', '-m', 'Release 1.0.0'], '/tmp/hubkit/stor/_user'))->shouldBeCalledTimes(1);
+        $processCliProphecy->run(new Process(['git', 'push', 'origin', 'v1.0.0'], '/tmp/hubkit/stor/_user'));
+
+        $cliProcess = $processCliProphecy->reveal();
+
+        $gitTempProphecy = $this->prophesize(GitTempRepository::class);
+        $gitTempProphecy->getRemote('git@github.com:park-manager/core.git', '1.0')->willReturn('/tmp/hubkit/stor/_core');
+        $gitTempProphecy->getRemote('git@github.com:park-manager/user.git', '1.0')->willReturn('/tmp/hubkit/stor/_user');
+        $gitTemp = $gitTempProphecy->reveal();
+
+        $service = new SplitshGit($this->createMock(Git::class), $cliProcess, $this->createMock(LoggerInterface::class), $gitTemp, self::SPLITSH_EXECUTABLE);
 
         $service->syncTags(
             '1.0.0',
             '1.0',
             [
-                '_core' => ['2c00338aef823d0c0916fc1b59ef49d0bb76f02f', 'git@github.com:park-manager/core.git', 5],
-                '_user' => ['3eed8083737422fe9ac2da9f4348423089fceb7f', 'git@github.com:park-manager/user.git', 3],
+                '/tmp/hubkit/stor/_core' => ['2c00338aef823d0c0916fc1b59ef49d0bb76f02f', 'git@github.com:park-manager/core.git', 5],
+                '/tmp/hubkit/stor/_user' => ['3eed8083737422fe9ac2da9f4348423089fceb7f', 'git@github.com:park-manager/user.git', 3],
             ]
         );
     }
@@ -122,8 +125,8 @@ final class SplitshGitTest extends TestCase
         $service = new SplitshGit(
             $git,
             $this->createMock(CliProcess::class),
-            $this->createMock(Filesystem::class),
             $this->createMock(LoggerInterface::class),
+            $this->createMock(GitTempRepository::class),
             self::SPLITSH_EXECUTABLE
         );
         $service->checkPrecondition();
@@ -139,8 +142,8 @@ final class SplitshGitTest extends TestCase
         $service = new SplitshGit(
             $git,
             $this->createMock(CliProcess::class),
-            $this->createMock(Filesystem::class),
             $this->createMock(LoggerInterface::class),
+            $this->createMock(GitTempRepository::class),
             self::SPLITSH_EXECUTABLE
         );
 
@@ -148,5 +151,14 @@ final class SplitshGitTest extends TestCase
         $this->expectExceptionMessage('Unable to perform split operation. Requires Git root directory of the repository.');
 
         $service->checkPrecondition();
+    }
+
+    private function getGitSplitShResult(string $hash): Process
+    {
+        $processProphecy = $this->prophesize(Process::class);
+        $processProphecy->getOutput()->willReturn($hash);
+        $processProphecy->getErrorOutput()->willReturn("\n5 commits created, 0 commits traversed, in 7ms");
+
+        return $processProphecy->reveal();
     }
 }

--- a/tests/Unit/Service/FilesystemTest.php
+++ b/tests/Unit/Service/FilesystemTest.php
@@ -77,6 +77,7 @@ final class FilesystemTest extends TestCase
         $path = $this->getTempdirPath('split');
 
         $sfFilesystem = $this->prophesize(SfFilesystem::class);
+        $sfFilesystem->mkdir('{:temp:}/hubkit')->shouldBeCalledOnce();
         $sfFilesystem->exists($path)->willReturn(false);
         $sfFilesystem->remove(Argument::any())->shouldNotBeCalled();
         $sfFilesystem->mkdir($path)->shouldBeCalledOnce();
@@ -97,6 +98,7 @@ final class FilesystemTest extends TestCase
         $path = $this->getTempdirPath('split');
 
         $sfFilesystem = $this->prophesize(SfFilesystem::class);
+        $sfFilesystem->mkdir('{:temp:}/hubkit')->shouldBeCalledOnce();
         $sfFilesystem->exists($path)->willReturn(true);
         $sfFilesystem->remove($path)->shouldBeCalledOnce();
         $sfFilesystem->mkdir($path)->shouldBeCalledOnce();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Tickets       | Fixes #58
| License       | MIT

The repository splitting is almost completely rewritten. 

Instead of keeping the split remotes locally the splits are pushed directly to a local temporary repository (by file-uri and not the remote-name) from where tagging and upmerging is also performed. Secondly, the temporary repositories are now kept as a cache to speed-up future processes.

Users are encouraged but not required to remove the old remotes to prevent conflicts with `git remote update`.

All handlers now use the same splitting logic as this was rather scattered and inconsistent.
- All split operations now show the actual splits that are performed, and ignored splits are automatically ignored.

Lastly, the `clear-cache` command was added to remove the cache and temp-files.

BC BREAKS: 

- The merge command no longer asks if you want to split, use the `--no-split` option instead.
- When a prefix directory is missing this now silent ignored with a warning, in Hubkit v2.0 this will produce an fatal error.