### PR TITLE
Use release hooks from the _hubkit branch

### DIFF
--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -36,7 +36,7 @@ The `release` command has a number of special options:
 ## Release hooks
 
 The `release` command allows to executes a script prior (pre) and/or after (post) after the release
-operation. See [Release Hooks](release-hooks.md) for details.
+operation. See [Release Hooks](../release-hooks.md) for details.
 
 *Note:* You need at least HubKit version 1.0.0-BETA18 to use release hooks.
 

--- a/docs/release-hooks.md
+++ b/docs/release-hooks.md
@@ -10,14 +10,17 @@ This might vary from updating the `composer.json` branch-alias, to creating a pu
 the new release.
 
 Now instead of doing this manually HubKit allows to hook-into the release process, but executing
-a custom script before and/or after a new release created.
+a custom callback before and/or after a new release is created.
 
 Both the pre and post hooks work the same way, but are executed at different stages.
 
 ## The Script
 
-Add a PHP  script named either `pre-release.php` or `post-release.php` in the project root folder
-at `.hubkit`, like `.hubkit/pre-release.php`.
+Add a PHP  script named either `pre-release.php` or `post-release.php` at the root folder
+of the "_hubkit" [configuration branch](config.md#local-configuration).
+
+**Caution:** Prior to HubKit v1.2 scripts were expected in the ".hubkit" folder at the root folder
+of the repository. Make sure to use the latest available release to prevent unexpected behavior.
 
 With the following contents:
 
@@ -37,12 +40,23 @@ return function (Container $container, Version $version, string $branch, ?string
     //
     // See \HubKit\Container for all services and there corresponding classes.
     // Note: Only the services listed above are covered by the BC promise.
+    
+    // !! CAUTION !!
+    //
+    // Hooks are loaded from a temporary location *outside of the repository*, use the `__DIR__`
+    // constant to load files related to the script, use `$container['current_dir']` 
+    // to get the actual location to the project repository.
+    //
 };
 ```
 
-**Note:** The hook is executed in the application's context, you have full access to entire applications flow!
+**Note:** The hook is executed in the HubKit application's context, you have full access to entire applications flow!
 
-Below you can find some examples how to use these hooks
+While possible it's' best not to load external dependencies as there is currently no promise this will work
+when HubKit uses similar dependencies. In this case it might be better to use the `process` service to execute
+a separate command.
+
+Below you can find some examples how to use these hooks.
 
 ### Updating the `composer.json` branch-alias (pre-release)
 
@@ -51,7 +65,7 @@ Below you can find some examples how to use these hooks
 
 declare(strict_types=1);
 
-// .hubkit/pre-release.php
+// pre-release.php (in the _hubkit branch)
 
 use Psr\Container\ContainerInterface as Container;
 use Rollerworks\Component\Version\Version;
@@ -82,7 +96,7 @@ return function (Container $container, Version $version, string $branch, ?string
 
 declare(strict_types=1);
 
-// .hubkit/post-release.php
+// post-release.php  (in the _hubkit branch)
 
 use Psr\Container\ContainerInterface as Container;
 use Rollerworks\Component\Version\Version;
@@ -120,7 +134,7 @@ error protections.
 
 declare(strict_types=1);
 
-// .hubkit/pre-release.php
+// pre-release.php  (in the _hubkit branch)
 
 use Psr\Container\ContainerInterface as Container;
 use Rollerworks\Component\Version\Version;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -476,6 +476,11 @@ parameters:
 			path: src/Service/GitHub.php
 
 		-
+			message: "#^Property HubKit\\\\Service\\\\HookScript\\:\\:\\$cwd \\(string\\|null\\) does not accept string\\|false\\.$#"
+			count: 1
+			path: src/Service/HookScript.php
+
+		-
 			message: "#^Method HubKit\\\\Service\\\\MessageValidator\\:\\:validateMessage\\(\\) should return array\\{string, string, string\\}\\|null but returns array\\{3, 'Unrelated commits…', string\\}\\.$#"
 			count: 1
 			path: src/Service/MessageValidator.php
@@ -484,11 +489,6 @@ parameters:
 			message: "#^Method HubKit\\\\Service\\\\MessageValidator\\:\\:validateMessage\\(\\) should return array\\{string, string, string\\}\\|null but returns array\\{5, 'Description…', string\\}\\.$#"
 			count: 1
 			path: src/Service/MessageValidator.php
-
-		-
-			message: "#^PHPDoc tag @var for property HubKit\\\\Service\\\\ReleaseHooks\\:\\:\\$cwd with type string\\|null is not subtype of native type bool\\|string\\.$#"
-			count: 1
-			path: src/Service/ReleaseHooks.php
 
 		-
 			message: "#^Parameter \\#1 \\$cmd of method HubKit\\\\Service\\\\CliProcess\\:\\:mustRun\\(\\) expects array\\<int, string\\>\\|Symfony\\\\Component\\\\Process\\\\Process, array\\<int, string\\|null\\> given\\.$#"

--- a/src/Container.php
+++ b/src/Container.php
@@ -75,7 +75,12 @@ class Container extends \Pimple\Container implements ContainerInterface
 
         $this['editor'] = static fn (self $container) => new Service\Editor($container['process'], $container['filesystem']);
 
-        $this['release_hooks'] = static fn (self $container) => new Service\ReleaseHooks($container, $container['git'], $container['logger']);
+        $this['release_hooks'] = static fn (self $container) => new Service\ReleaseHooks(
+            $container['git.file_reader'],
+            $container['logger'],
+            $container,
+            $container['git']
+        );
 
         //
         // Third-party APIs

--- a/src/Service/HookScript.php
+++ b/src/Service/HookScript.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HubKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Service;
+
+use HubKit\Service\Git\GitFileReader;
+use Psr\Log\LoggerInterface;
+
+abstract class HookScript
+{
+    public function __construct(
+        protected readonly GitFileReader $gitFileReader,
+        protected readonly LoggerInterface $logger,
+        protected ?string $cwd = null,
+    ) {
+        $this->cwd = $cwd ?? getcwd();
+    }
+
+    protected function findScript(string $name): ?string
+    {
+        if ($this->gitFileReader->fileExists('_hubkit', $name . '.php')) {
+            $this->logger->debug('Hook script {name}.php was found in the "_hubkit" branch.', ['name' => $name]);
+
+            return $this->gitFileReader->getFile('_hubkit', $name . '.php');
+        }
+
+        $scriptFile = $this->cwd . '/.hubkit/' . $name . '.php';
+
+        if (file_exists($scriptFile)) {
+            $this->logger->warning('Hook script {name}.php was found at "{script}". Move this file to the "_hubkit" configuration branch instead.', ['name' => $name, 'script' => $this->cwd . '/.hubkit']);
+
+            trigger_deprecation('park-manager/hubkit', 'v1.2.0', 'Storing hook scripts in ".hubkit" is deprecated and will no longer work in HubKit v2.0. Use the "_hubkit" configuration branch to store hook scripts instead.');
+
+            return $scriptFile;
+        }
+
+        return null;
+    }
+
+    protected function getHookCallback(string $scriptFile): callable
+    {
+        $hookCallback = include $scriptFile;
+
+        if (! \is_callable($hookCallback)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Expected script file "%s" to return a callable, got "%s" instead.',
+                    $scriptFile,
+                    \gettype($hookCallback)
+                )
+            );
+        }
+
+        return $hookCallback;
+    }
+}

--- a/tests/Service/Fixtures/empty-project/.gitkeep
+++ b/tests/Service/Fixtures/empty-project/.gitkeep
@@ -1,0 +1,1 @@
+El Barto was not here.

--- a/tests/Service/ReleaseHooksTest.php
+++ b/tests/Service/ReleaseHooksTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace HubKit\Tests\Service;
 
 use HubKit\Service\Git;
+use HubKit\Service\Git\GitFileReader;
 use HubKit\Service\ReleaseHooks;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -30,18 +31,23 @@ final class ReleaseHooksTest extends TestCase
     use ProphecyTrait;
 
     /** @test */
-    public function it_does_nothing_when_there_are_hooks(): void
+    public function it_does_nothing_when_there_are_no_hooks(): void
     {
         $gitProphecy = $this->prophesize(Git::class);
         $gitProphecy->isWorkingTreeReady()->willReturn(true);
         $git = $gitProphecy->reveal();
 
         $loggerProphecy = $this->prophesize(LoggerInterface::class);
-        $loggerProphecy->debug('File {script} was not found. pre-release script will not be executed.', Argument::any())->shouldBeCalled();
-        $loggerProphecy->debug('File {script} was not found. post-release script will not be executed.', Argument::any())->shouldBeCalled();
+        $loggerProphecy->debug(Argument::any(), Argument::any())->shouldNotBeCalled();
         $logger = $loggerProphecy->reveal();
 
-        $hooks = new ReleaseHooks($this->createMock(ContainerInterface::class), $git, $logger, __DIR__ . '/Fixtures/project-without-hooks');
+        $hooks = new ReleaseHooks(
+            $this->getGitFileReader(),
+            $logger,
+            $this->createMock(ContainerInterface::class),
+            $git,
+            __DIR__ . '/Fixtures/project-without-hooks'
+        );
 
         $version = Version::fromString('1.0');
 
@@ -57,11 +63,16 @@ final class ReleaseHooksTest extends TestCase
         $git = $gitProphecy->reveal();
 
         $loggerProphecy = $this->prophesize(LoggerInterface::class);
-        $loggerProphecy->debug('File {script} was not found. pre-release script will not be executed.', Argument::any())->shouldNotBeCalled();
-        $loggerProphecy->debug('File {script} was not found. post-release script will not be executed.', Argument::any())->shouldBeCalled();
+        $loggerProphecy->debug('Hook script {name}.php was found in the "_hubkit" branch.', ['name' => 'pre-release'])->shouldBeCalled();
         $logger = $loggerProphecy->reveal();
 
-        $hooks = new ReleaseHooks($this->createMock(ContainerInterface::class), $git, $logger, __DIR__ . '/Fixtures/project-pre-release');
+        $hooks = new ReleaseHooks(
+            $this->getGitFileReader(pre: __DIR__ . '/Fixtures/project-pre-release/.hubkit/pre-release.php'),
+            $logger,
+            $this->createMock(ContainerInterface::class),
+            $git,
+            __DIR__ . '/Fixtures/empty-project'
+        );
 
         $version = Version::fromString('1.0');
 
@@ -77,11 +88,16 @@ final class ReleaseHooksTest extends TestCase
         $git = $gitProphecy->reveal();
 
         $loggerProphecy = $this->prophesize(LoggerInterface::class);
-        $loggerProphecy->debug('File {script} was not found. pre-release script will not be executed.', Argument::any())->shouldBeCalled();
-        $loggerProphecy->debug('File {script} was not found. post-release script will not be executed.', Argument::any())->shouldNotBeCalled();
+        $loggerProphecy->debug('Hook script {name}.php was found in the "_hubkit" branch.', ['name' => 'post-release'])->shouldBeCalled();
         $logger = $loggerProphecy->reveal();
 
-        $hooks = new ReleaseHooks($this->createMock(ContainerInterface::class), $git, $logger, __DIR__ . '/Fixtures/project-post-release');
+        $hooks = new ReleaseHooks(
+            $this->getGitFileReader(post: __DIR__ . '/Fixtures/project-post-release/.hubkit/post-release.php'),
+            $logger,
+            $this->createMock(ContainerInterface::class),
+            $git,
+            __DIR__ . '/Fixtures/empty-project'
+        );
 
         $version = Version::fromString('1.0');
 
@@ -97,15 +113,134 @@ final class ReleaseHooksTest extends TestCase
         $git = $gitProphecy->reveal();
 
         $loggerProphecy = $this->prophesize(LoggerInterface::class);
-        $loggerProphecy->debug('File {script} was not found. pre-release script will not be executed.', Argument::any())->shouldNotBeCalled();
-        $loggerProphecy->debug('File {script} was not found. post-release script will not be executed.', Argument::any())->shouldNotBeCalled();
+        $loggerProphecy->debug('Hook script {name}.php was found in the "_hubkit" branch.', ['name' => 'pre-release'])->shouldBeCalled();
+        $loggerProphecy->debug('Hook script {name}.php was found in the "_hubkit" branch.', ['name' => 'post-release'])->shouldBeCalled();
         $logger = $loggerProphecy->reveal();
 
-        $hooks = new ReleaseHooks($this->createMock(ContainerInterface::class), $git, $logger, __DIR__ . '/Fixtures/project-pre-post-release');
+        $hooks = new ReleaseHooks(
+            $this->getGitFileReader(
+                pre: __DIR__ . '/Fixtures/project-pre-post-release/.hubkit/pre-release.php',
+                post: __DIR__ . '/Fixtures/project-pre-post-release/.hubkit/post-release.php'
+            ),
+            $logger,
+            $this->createMock(ContainerInterface::class),
+            $git,
+            __DIR__ . '/Fixtures/project-pre-post-release'
+        );
 
         $version = Version::fromString('1.0');
 
         self::assertEquals('executed-pre', $hooks->preRelease($version, 'master', null, 'Something changed.'));
         self::assertEquals('executed-post', $hooks->postRelease($version, 'master', null, 'Something changed.'));
+    }
+
+    /**
+     * @test
+     *
+     * @group legacy
+     */
+    public function it_executes_pre_hook_legacy(): void
+    {
+        $gitProphecy = $this->prophesize(Git::class);
+        $gitProphecy->isWorkingTreeReady()->willReturn(true);
+        $git = $gitProphecy->reveal();
+
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+        $loggerProphecy->warning('Hook script {name}.php was found at "{script}". Move this file to the "_hubkit" configuration branch instead.', ['name' => 'pre-release', 'script' => __DIR__ . '/Fixtures/project-pre-release/.hubkit'])->shouldBeCalled();
+        $logger = $loggerProphecy->reveal();
+
+        $hooks = new ReleaseHooks(
+            $this->getGitFileReader(),
+            $logger,
+            $this->createMock(ContainerInterface::class),
+            $git,
+            __DIR__ . '/Fixtures/project-pre-release'
+        );
+
+        $version = Version::fromString('1.0');
+
+        self::assertEquals('executed-pre', $hooks->preRelease($version, 'master', null, 'Something changed.'));
+        self::assertEmpty($hooks->postRelease($version, 'master', null, 'Something changed.'));
+    }
+
+    /**
+     * @test
+     *
+     * @group legacy
+     */
+    public function it_executes_post_hook_legacy(): void
+    {
+        $gitProphecy = $this->prophesize(Git::class);
+        $gitProphecy->isWorkingTreeReady()->willReturn(true);
+        $git = $gitProphecy->reveal();
+
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+        $loggerProphecy->warning('Hook script {name}.php was found at "{script}". Move this file to the "_hubkit" configuration branch instead.', ['name' => 'post-release', 'script' => __DIR__ . '/Fixtures/project-post-release/.hubkit'])->shouldBeCalled();
+        $logger = $loggerProphecy->reveal();
+
+        $hooks = new ReleaseHooks(
+            $this->getGitFileReader(),
+            $logger,
+            $this->createMock(ContainerInterface::class),
+            $git,
+            __DIR__ . '/Fixtures/project-post-release'
+        );
+
+        $version = Version::fromString('1.0');
+
+        self::assertEmpty($hooks->preRelease($version, 'master', null, 'Something changed.'));
+        self::assertEquals('executed-post', $hooks->postRelease($version, 'master', null, 'Something changed.'));
+    }
+
+    /**
+     * @test
+     *
+     * @group legacy
+     */
+    public function it_executes_pre_post_hook_legacy(): void
+    {
+        $gitProphecy = $this->prophesize(Git::class);
+        $gitProphecy->isWorkingTreeReady()->willReturn(true);
+        $git = $gitProphecy->reveal();
+
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+        $loggerProphecy->warning('Hook script {name}.php was found at "{script}". Move this file to the "_hubkit" configuration branch instead.', ['name' => 'pre-release', 'script' => __DIR__ . '/Fixtures/project-pre-post-release/.hubkit'])->shouldBeCalled();
+        $loggerProphecy->warning('Hook script {name}.php was found at "{script}". Move this file to the "_hubkit" configuration branch instead.', ['name' => 'post-release', 'script' => __DIR__ . '/Fixtures/project-pre-post-release/.hubkit'])->shouldBeCalled();
+        $logger = $loggerProphecy->reveal();
+
+        $hooks = new ReleaseHooks(
+            $this->getGitFileReader(),
+            $logger,
+            $this->createMock(ContainerInterface::class),
+            $git,
+            __DIR__ . '/Fixtures/project-pre-post-release'
+        );
+
+        $version = Version::fromString('1.0');
+
+        self::assertEquals('executed-pre', $hooks->preRelease($version, 'master', null, 'Something changed.'));
+        self::assertEquals('executed-post', $hooks->postRelease($version, 'master', null, 'Something changed.'));
+    }
+
+    /**
+     * @param non-empty-string|null $pre
+     * @param non-empty-string|null $post
+     */
+    private function getGitFileReader(string $pre = null, string $post = null): GitFileReader
+    {
+        $gitFileReaderProphecy = $this->prophesize(GitFileReader::class);
+
+        $gitFileReaderProphecy->fileExists('_hubkit', 'pre-release.php')->willReturn($pre !== null);
+        $gitFileReaderProphecy->fileExists('_hubkit', 'post-release.php')->willReturn($post !== null);
+
+        if ($pre !== null) {
+            $gitFileReaderProphecy->getFile('_hubkit', 'pre-release.php')->willReturn($pre);
+        }
+
+        if ($post !== null) {
+            $gitFileReaderProphecy->getFile('_hubkit', 'post-release.php')->willReturn($post);
+        }
+
+        return $gitFileReaderProphecy->reveal();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tickets       |
| License       | MIT

Use the pre/post -release script located in the "_hubkit" configuration branch.
Using the '.hubkit' directory is still supported but deprecated and will no longer work in HubKit v2.0

Bonus. This new hook technique will be made more widely available for other commands as well,
including merge, upmerge, split-repo, create-repo, switch-base, checkout; which wasn't possible prior due to the changing state of the active branch.