### PR TITLE
Allow to disable upmerge for a specific branch

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -81,7 +81,7 @@ Each branch has the following options:
 |------------------|---------|----------|-------------------------------------------------------------------------------------------------------------------|
 | `sync-tags`      | Boolean | `true`   | _Only when 'split' targets are configured_, <br/>whether new tags should be synchronized when creating a release. |
 | `ignore-default` | Boolean | `false`  | Whether the ':default' configuration should be ignored.                                                           |
-| `upmerge`        | Boolean | `true`   | _Not supported at the moment._                                                                                    |
+| `upmerge`        | Boolean | `true`   | Set to false to disable upmerge for this branch configuration, and continue with next possible version.           |
 | `split`          | array   | `[]`     | See Repository splitting for details.                                                                             |
 
 ```php
@@ -96,9 +96,9 @@ Each branch has the following options:
             'docs' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => false],
         ],
     ],
-    '1.0' => false, // Disabled
+    '1.0' => false, // Disabled all
     '2.x' => [ // '2.x' is a pattern equivalent to '/2\.\d+/'
-        'upmerge' => false,
+        'upmerge' => false, // Disable upmerge for this branch, effectively all of the '2.x' range are skipped
         // Split's is inherited and merged from ':default'
         'split' => [
             'src/Module/DomainRegModule' => 'git@github.com:hubkit-sandbox/webhosting-module.git',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -101,8 +101,13 @@ parameters:
 			path: src/Cli/Handler/SwitchBaseHandler.php
 
 		-
-			message: "#^Binary operation \"\\+\" between int\\|string\\|false and 1 results in an error\\.$#"
-			count: 6
+			message: "#^Parameter \\#2 \\$branches of method HubKit\\\\Cli\\\\Handler\\\\UpMergeHandler\\:\\:dryMergeBranches\\(\\) expects array\\<string\\>, array\\<string\\|false\\> given\\.$#"
+			count: 1
+			path: src/Cli/Handler/UpMergeHandler.php
+
+		-
+			message: "#^Parameter \\#2 \\$branches of method HubKit\\\\Cli\\\\Handler\\\\UpMergeHandler\\:\\:mergeBranches\\(\\) expects array\\<string\\>, array\\<string\\|false\\> given\\.$#"
+			count: 1
 			path: src/Cli/Handler/UpMergeHandler.php
 
 		-
@@ -138,6 +143,26 @@ parameters:
 		-
 			message: "#^Method HubKit\\\\Config\\:\\:getOrFail\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Parameter \\#1 \\$host of method HubKit\\\\Config\\:\\:getForRepository\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Parameter \\#2 \\$repository of method HubKit\\\\Config\\:\\:getForRepository\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Parameter \\#4 \\$configPath of class HubKit\\\\BranchConfig constructor expects array\\<int, string\\>\\|null, array\\<int, string\\|null\\> given\\.$#"
+			count: 2
+			path: src/Config.php
+
+		-
+			message: "#^Parameter \\$configPath of class HubKit\\\\BranchConfig constructor expects array\\<int, string\\>\\|null, array\\<int, string\\|null\\> given\\.$#"
+			count: 2
 			path: src/Config.php
 
 		-

--- a/src/Config.php
+++ b/src/Config.php
@@ -133,8 +133,11 @@ final class Config
         return $globalConfig;
     }
 
-    public function getBranchConfig(string $host, string $repository, string $branchName): BranchConfig
+    public function getBranchConfig(string $branchName, string $host = null, string $repository = null): BranchConfig
     {
+        $host ??= $this->activeHost;
+        $repository ??= $this->activeRepository;
+
         $repoConfig = $this->getForRepository($host, $repository, $isLocal);
         $configPath = $isLocal ? ['_local', 'branches'] : ['repositories', $host, 'repos', $repository, 'branches'];
 

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -213,7 +213,7 @@ final class ConfigFactory
                 ->normalizeKeys(false)
                 ->treatFalseLike(['upmerge' => false, 'sync-tags' => true, 'ignore-default' => true, 'split' => []])
                 ->children()
-                    ->booleanNode('upmerge')->defaultTrue()->end()
+                    ->booleanNode('upmerge')->defaultTrue()->info('Set to false to disable upmerge for this branch configuration, and continue with next possible version')->end()
                     ->booleanNode('sync-tags')->defaultTrue()->end()
                     ->booleanNode('ignore-default')->defaultFalse()->info('Ignore the ":default" branch configuration')->end()
                     ->arrayNode('split')

--- a/src/Service/BranchSplitsh.php
+++ b/src/Service/BranchSplitsh.php
@@ -84,7 +84,11 @@ class BranchSplitsh
 
     private function getBranchConfig(string $branch): BranchConfig
     {
-        $branchConfig = $this->config->getBranchConfig($this->github->getHostname(), $this->github->getOrganization() . '/' . $this->github->getRepository(), $branch);
+        $branchConfig = $this->config->getBranchConfig(
+            $branch,
+            $this->github->getHostname(),
+            $this->github->getOrganization() . '/' . $this->github->getRepository()
+        );
 
         if (empty($branchConfig->config['split'])) {
             $this->style->text(sprintf('No repository-split targets were found in config "[%s]".', implode('][', $branchConfig->configPath)));

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -317,7 +317,7 @@ final class ConfigTest extends TestCase
                 configName: '1.0',
                 configPath: ['repositories', 'github.com', 'repos', 'hubkit-sandbox/empire', 'branches', '1.0'],
             ),
-            $config->getBranchConfig('github.com', 'hubkit-sandbox/empire', '1.0')
+            $config->getBranchConfig('1.0', 'github.com', 'hubkit-sandbox/empire')
         );
 
         self::assertEquals(
@@ -327,7 +327,7 @@ final class ConfigTest extends TestCase
                 configName: '2.0',
                 configPath: ['repositories', 'github.com', 'repos', 'hubkit-sandbox/empire', 'branches', '2.0'],
             ),
-            $config->getBranchConfig('github.com', 'hubkit-sandbox/empire', '2.0')
+            $config->getBranchConfig('2.0', 'github.com', 'hubkit-sandbox/empire')
         );
 
         self::assertEquals(
@@ -337,7 +337,7 @@ final class ConfigTest extends TestCase
                 configName: '#3.x',
                 configPath: ['repositories', 'github.com', 'repos', 'hubkit-sandbox/empire', 'branches', '#3.x'],
             ),
-            $config->getBranchConfig('github.com', 'hubkit-sandbox/empire', '#3.x')
+            $config->getBranchConfig('#3.x', 'github.com', 'hubkit-sandbox/empire')
         );
 
         self::assertEquals(
@@ -355,7 +355,7 @@ final class ConfigTest extends TestCase
                 configName: '1.0',
                 configPath: ['repositories', 'github.com', 'repos', 'hubkit-sandbox/application', 'branches', '1.0'],
             ),
-            $config->getBranchConfig('github.com', 'hubkit-sandbox/application', '1.0')
+            $config->getBranchConfig('1.0', 'github.com', 'hubkit-sandbox/application')
         );
 
         self::assertEquals(
@@ -372,7 +372,7 @@ final class ConfigTest extends TestCase
                 configName: '1.*',
                 configPath: ['repositories', 'github.com', 'repos', 'hubkit-sandbox/application', 'branches', '1.*'],
             ),
-            $config->getBranchConfig('github.com', 'hubkit-sandbox/application', '1.1')
+            $config->getBranchConfig('1.1', 'github.com', 'hubkit-sandbox/application')
         );
 
         self::assertEquals(
@@ -389,7 +389,7 @@ final class ConfigTest extends TestCase
                 configName: '2.x',
                 configPath: ['repositories', 'github.com', 'repos', 'hubkit-sandbox/application', 'branches', '2.x'],
             ),
-            $config->getBranchConfig('github.com', 'hubkit-sandbox/application', '2.1')
+            $config->getBranchConfig('2.1', 'github.com', 'hubkit-sandbox/application')
         );
 
         self::assertEquals(
@@ -406,7 +406,7 @@ final class ConfigTest extends TestCase
                 configName: '/[3-9]\.\d+/',
                 configPath: ['repositories', 'github.com', 'repos', 'hubkit-sandbox/application', 'branches', '/[3-9]\.\d+/'],
             ),
-            $config->getBranchConfig('github.com', 'hubkit-sandbox/application', '4.5')
+            $config->getBranchConfig('4.5', 'github.com', 'hubkit-sandbox/application')
         );
 
         $config->setActiveRepository('github.com', 'hubkit-sandbox/empire');
@@ -425,7 +425,7 @@ final class ConfigTest extends TestCase
                 configName: '1.*',
                 configPath: ['_local', 'branches', '1.*'],
             ),
-            $config->getBranchConfig('github.com', 'hubkit-sandbox/empire', '1.0')
+            $config->getBranchConfig('1.0', 'github.com', 'hubkit-sandbox/empire')
         );
 
         self::assertEquals(
@@ -443,7 +443,7 @@ final class ConfigTest extends TestCase
                 configName: '1.0',
                 configPath: ['repositories', 'github.com', 'repos', 'hubkit-sandbox/application', 'branches', '1.0'],
             ),
-            $config->getBranchConfig('github.com', 'hubkit-sandbox/application', '1.0')
+            $config->getBranchConfig('1.0', 'github.com', 'hubkit-sandbox/application')
         );
 
         // No explicit branch found, resolved from :default
@@ -460,7 +460,7 @@ final class ConfigTest extends TestCase
                 configName: ':default',
                 configPath: ['repositories', 'github.com', 'repos', 'hubkit-sandbox/application', 'branches', ':default'],
             ),
-            $config->getBranchConfig('github.com', 'hubkit-sandbox/application', '10.5')
+            $config->getBranchConfig('10.5', 'github.com', 'hubkit-sandbox/application')
         );
 
         // No explicit branch found, default ignored
@@ -475,7 +475,7 @@ final class ConfigTest extends TestCase
                 configName: '11.0',
                 configPath: ['repositories', 'github.com', 'repos', 'hubkit-sandbox/application', 'branches', '11.0'],
             ),
-            $config->getBranchConfig('github.com', 'hubkit-sandbox/application', '11.0')
+            $config->getBranchConfig('11.0', 'github.com', 'hubkit-sandbox/application')
         );
     }
 }


### PR DESCRIPTION
Effectively disabling upmerge for a brach will continue with other branches

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    |no
| Deprecations? |no
| Tickets       | 
| License       | MIT

Effectively disabling upmerge for a brach and continues with a next possible version.

Use-case: Say `3.[1-3]` is disabled but you still want to upmerge 2.4 (LTS) into 3.4.