### PR TITLE
Add way to 'automatically' create split targets

### DIFF
--- a/docs/commands/repo-create.md
+++ b/docs/commands/repo-create.md
@@ -10,6 +10,9 @@ $ hubkit repo-create park-manager/hubkit
 This creates the "hubkit" repository in the "park-manager" organization. To create a
 private repository (may require a paid plan) use the `--private` option.
 
+**Tip:** Since HubKit v1.6 use the `split-create` command to automatically create
+repositories for split targets.
+
 # Special options
 
 The `repo-create` command has a number of special options:

--- a/docs/split-repositories.md
+++ b/docs/split-repositories.md
@@ -15,8 +15,7 @@ be configured. Each target consists of a prefix (directory path),
 target repository and some additional options like if tag-synchronizing is enabled.
 
 **Suffice to say the repositories must exist! They are not automatically created,
-use the [repo-create](commands/repo-create.md) command with the correct arguments
-to create the repositories.**
+use the `split-create` command to create the repositories.**
 
 See [Configuration](config.md) how to configure your splits.
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -96,6 +96,16 @@ parameters:
 			path: src/Cli/Handler/SelfDiagnoseHandler.php
 
 		-
+			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\SplitCreatedHandler\\:\\:getSplits\\(\\) should return array\\<string, string\\> but returns array\\<int\\|string, mixed\\>\\.$#"
+			count: 1
+			path: src/Cli/Handler/SplitCreatedHandler.php
+
+		-
+			message: "#^PHPDoc tag @var for variable \\$config has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Cli/Handler/SplitCreatedHandler.php
+
+		-
 			message: "#^Parameter \\#1 \\$string of function trim expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/Cli/Handler/SwitchBaseHandler.php
@@ -112,7 +122,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Webmozart\\\\Console\\\\Api\\\\Config\\\\ApplicationConfig\\|Webmozart\\\\Console\\\\Api\\\\Config\\\\CommandConfig\\:\\:end\\(\\)\\.$#"
-			count: 14
+			count: 15
 			path: src/Cli/HubKitApplicationConfig.php
 
 		-
@@ -397,7 +407,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method repo\\(\\) on Github\\\\Client\\|null\\.$#"
-			count: 7
+			count: 8
 			path: src/Service/GitHub.php
 
 		-
@@ -1131,24 +1141,99 @@ parameters:
 			path: tests/Handler/ReleaseHandlerTest.php
 
 		-
-			message: "#^Constant HubKit\\\\Tests\\\\Handler\\\\SplitRepoHandlerTest\\:\\:HEAD_SHA is unused\\.$#"
+			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\SplitCreatedHandlerTest\\:\\:assertOutputMatches\\(\\) has parameter \\$expectedLines with no type specified\\.$#"
 			count: 1
-			path: tests/Handler/SplitRepoHandlerTest.php
+			path: tests/Handler/SplitCreatedHandlerTest.php
 
 		-
-			message: "#^Constant HubKit\\\\Tests\\\\Handler\\\\SplitRepoHandlerTest\\:\\:MERGE_SHA is unused\\.$#"
+			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\SplitCreatedHandlerTest\\:\\:assertOutputMatches\\(\\) has parameter \\$regex with no type specified\\.$#"
 			count: 1
-			path: tests/Handler/SplitRepoHandlerTest.php
+			path: tests/Handler/SplitCreatedHandlerTest.php
 
 		-
-			message: "#^Constant HubKit\\\\Tests\\\\Handler\\\\SplitRepoHandlerTest\\:\\:PR_BRANCH is unused\\.$#"
+			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\SplitCreatedHandlerTest\\:\\:assertOutputNotMatches\\(\\) has parameter \\$lines with no type specified\\.$#"
 			count: 1
-			path: tests/Handler/SplitRepoHandlerTest.php
+			path: tests/Handler/SplitCreatedHandlerTest.php
 
 		-
-			message: "#^Constant HubKit\\\\Tests\\\\Handler\\\\SplitRepoHandlerTest\\:\\:PR_NUMBER is unused\\.$#"
+			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\SplitCreatedHandlerTest\\:\\:assertOutputNotMatches\\(\\) has parameter \\$regex with no type specified\\.$#"
 			count: 1
-			path: tests/Handler/SplitRepoHandlerTest.php
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\SplitCreatedHandlerTest\\:\\:createStyle\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\SplitCreatedHandlerTest\\:\\:getDisplay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\SplitCreatedHandlerTest\\:\\:getInputStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\SplitCreatedHandlerTest\\:\\:getInputStream\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of class Symfony\\\\Component\\\\Console\\\\Output\\\\StreamOutput constructor expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fwrite expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function rewind expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$git of class HubKit\\\\Cli\\\\Handler\\\\SplitCreatedHandler constructor expects HubKit\\\\Service\\\\Git, object given\\.$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertDoesNotMatchRegularExpression\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertMatchesRegularExpression\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$github of class HubKit\\\\Cli\\\\Handler\\\\SplitCreatedHandler constructor expects HubKit\\\\Service\\\\GitHub, object given\\.$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Property HubKit\\\\Tests\\\\Handler\\\\SplitCreatedHandlerTest\\:\\:\\$git with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Property HubKit\\\\Tests\\\\Handler\\\\SplitCreatedHandlerTest\\:\\:\\$github with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
+
+		-
+			message: "#^Property HubKit\\\\Tests\\\\Handler\\\\SplitCreatedHandlerTest\\:\\:\\$output \\(Symfony\\\\Component\\\\Console\\\\Output\\\\StreamOutput\\) does not accept Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface\\.$#"
+			count: 1
+			path: tests/Handler/SplitCreatedHandlerTest.php
 
 		-
 			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\SplitRepoHandlerTest\\:\\:assertOutputMatches\\(\\) has parameter \\$expectedLines with no type specified\\.$#"

--- a/src/Cli/Handler/SplitCreatedHandler.php
+++ b/src/Cli/Handler/SplitCreatedHandler.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HubKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Cli\Handler;
+
+use Github\Exception\RuntimeException as GitHubRuntimeException;
+use HubKit\Service\Git;
+use HubKit\Service\GitHub;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Webmozart\Console\Api\Args\Args;
+
+class SplitCreatedHandler extends GitBaseHandler
+{
+    public function handle(Args $args): void
+    {
+        $this->git->guardWorkingTreeReady();
+        $this->git->remoteUpdate('upstream');
+
+        $this->style->title('Repository Split Create');
+        $this->informationHeader();
+
+        $isPrivate = $this->github->getRepoInfo($this->github->getOrganization(), $this->github->getRepository())['private'];
+
+        /** @var array<string, GitHub> $hosts */
+        $hosts = [];
+        $hosts[$this->github->getHostname()] = $this->github;
+
+        if ($isPrivate) {
+            $this->style->note('The main repository is private, split repositories will be created as private.');
+        }
+
+        $splits = $this->getSplits();
+
+        if (\count($splits) === 0) {
+            $this->style->block('No repository splits found, or splits are disabled for all branches.', 'INFO', 'fg=black;bg=yellow', ' ', true);
+
+            return;
+        }
+
+        foreach ($splits as $url) {
+            ['host' => $host, 'org' => $org, 'repo' => $repo] = Git::getGitUrlInfo($url);
+
+            if (! isset($hosts[$host])) {
+                $hosts[$host] = $this->github->createForHost($host);
+            }
+
+            $this->createRepository($hosts[$host], $org, $repo, public: ! $isPrivate);
+        }
+
+        $this->style->success('Repository splits were created.');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getSplits(): array
+    {
+        $repositories = [];
+
+        /** @var array<string, array{'split': array<string, array{'url': string|bool}>}|array> $config */
+        foreach ($this->config->getForRepository($this->github->getHostname(), $this->github->getOrganization() . '/' . $this->github->getRepository())['branches'] ?? [] as $config) {
+            if (! isset($config['split']) || \count($config['split']) === 0) {
+                continue;
+            }
+
+            foreach ($config['split'] as $split) {
+                if ($split['url'] !== false) {
+                    $repositories[$split['url']] = $split['url'];
+                }
+            }
+        }
+
+        return $repositories;
+    }
+
+    private function createRepository(GitHub $gitHub, string $org, string $repo, bool $public): void
+    {
+        try {
+            $url = $gitHub->getRepoInfo($org, $repo)['html_url'];
+
+            $this->style->writeln(sprintf('<fg=yellow> [INFO] Repository %s already exists.</>', OutputFormatter::escape($url)));
+        } catch (GitHubRuntimeException $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+
+            $url = $gitHub->createRepo($org, $repo, public: $public, hasIssues: false)['html_url'];
+
+            $this->style->writeln(sprintf('<fg=green> [OK] Repository %s was created.</>', OutputFormatter::escape($url)));
+        }
+    }
+}

--- a/src/Cli/HubKitApplicationConfig.php
+++ b/src/Cli/HubKitApplicationConfig.php
@@ -164,6 +164,7 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
 
             ->beginCommand('split-repo')
             ->setDescription('Split the repository into configured targets. Requires "repos" is configured in config.php')
+            ->setHelp('Splits the current repository into configured targets, use the `split-create` command to set-up missing repositories')
             ->addArgument('branch', Argument::OPTIONAL | Argument::STRING, 'Branch to checkout and split from, uses current when omitted')
             ->addOption('dry-run', null, Option::NO_VALUE | Option::BOOLEAN, 'Show which operations would have been performed (without actually splitting)')
             ->addOption('prefix', null, Option::REQUIRED_VALUE | Option::STRING, 'Split only a specific prefix instead of all')
@@ -174,6 +175,18 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
                     $this->container['github'],
                     $this->container['config'],
                     $this->container['branch_splitsh_git']
+                );
+            })
+            ->end()
+
+            ->beginCommand('split-create')
+            ->setDescription('Create repositories for the current repository configured split targets (already existing repositories are ignored). Requires "repos" is configured in config.php')
+            ->setHandler(function () {
+                return new Handler\SplitCreatedHandler(
+                    $this->container['style'],
+                    $this->container['git'],
+                    $this->container['github'],
+                    $this->container['config'],
                 );
             })
             ->end()

--- a/src/Service/GitHub.php
+++ b/src/Service/GitHub.php
@@ -68,6 +68,16 @@ class GitHub
         }
     }
 
+    public function createForHost(string $hostname): self
+    {
+        $github = clone $this;
+        $github->initializeForHost($hostname);
+        $github->organization = '';
+        $github->repository = '';
+
+        return $github;
+    }
+
     public function setRepository(string $organization, string $repository): void
     {
         $this->organization = $organization;
@@ -115,6 +125,14 @@ class GitHub
             null, // team-id
             false // auto-init
         );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getRepoInfo(string $organization, string $name): array
+    {
+        return $this->client->repo()->show($organization, $name);
     }
 
     public function getIssue(int $number)

--- a/src/Service/SplitshGit.php
+++ b/src/Service/SplitshGit.php
@@ -63,7 +63,7 @@ class SplitshGit
         // This is much safer than keeping all the remotes local as this fails with git update (puling-in conflicting tags)
         $this->git->pushToRemote('file://' . $tempDir, $sha . ':refs/heads/' . $targetBranch);
 
-        $this->process->mustRun(new Process(['git', 'push', 'origin', $targetBranch . ':refs/heads/' . $targetBranch], $tempDir));
+        $this->process->mustRun(new Process(['git', 'push', 'origin', $targetBranch . ':refs/heads/' . $targetBranch], $tempDir), 'If the destination does not exist run the `split-create` command.');
 
         return [$sha, $url, $tempDir];
     }

--- a/tests/Handler/SplitCreatedHandlerTest.php
+++ b/tests/Handler/SplitCreatedHandlerTest.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HubKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Tests\Handler;
+
+use Github\Exception\RuntimeException as GitHubRuntimeException;
+use HubKit\Cli\Handler\SplitCreatedHandler;
+use HubKit\Config;
+use HubKit\Service\Git;
+use HubKit\Service\GitHub;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Webmozart\Console\Api\Args\Args;
+use Webmozart\Console\Api\Args\Format\ArgsFormat;
+use Webmozart\Console\Args\StringArgs;
+
+/**
+ * @internal
+ */
+final class SplitCreatedHandlerTest extends TestCase
+{
+    use ProphecyTrait;
+    use SymfonyStyleTrait;
+
+    private ObjectProphecy $git;
+    private ObjectProphecy $github;
+    private Config $config;
+
+    /** @before */
+    public function setUpCommandHandler(): void
+    {
+        $this->git = $this->prophesize(Git::class);
+        $this->git->guardWorkingTreeReady()->shouldBeCalled();
+        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->getActiveBranchName()->willReturn('master');
+
+        $this->github = $this->prophesize(GitHub::class);
+        $this->github->getHostname()->willReturn('github.com');
+        $this->github->getOrganization()->willReturn('hubkit-sandbox');
+        $this->github->getRepository()->willReturn('empire');
+        $this->github->getAuthUsername()->willReturn('sstok');
+
+        $this->github->getRepoInfo('hubkit-sandbox', 'empire')->willReturn(['private' => false]);
+        $this->github->createRepo(Argument::any(), Argument::any(), Argument::any(), Argument::any())->will(static fn (array $a) => throw new \InvalidArgumentException(sprintf('Creation for %s/%s was not expected', $a[0], $a[1])));
+
+        $this->config = new Config([
+            'schema_version' => 2,
+            'github' => [
+                'github.com' => [
+                    'username' => 'sstok',
+                    'api_token' => 'CHANGE-ME',
+                ],
+            ],
+            'repositories' => [
+                'github.com' => [
+                    'repos' => [
+                        'hubkit-sandbox/empire' => [
+                            'branches' => [
+                                'master' => [
+                                    'sync-tags' => true,
+                                    'split' => [
+                                        'src/Module/CoreModule' => ['url' => 'git@github.com:hubkit-sandbox/core-module.git'],
+                                        'src/Module/WebhostingModule' => ['url' => 'git@github.com:hubkit-sandbox/webhosting-module.git'],
+                                        'docs' => ['url' => false],
+                                    ],
+                                ],
+                                '2.x' => [
+                                    'sync-tags' => true,
+                                    'split' => [
+                                        'src/Module/CoreModule' => ['url' => 'git@github.com:hubkit-sandbox/core-module.git'],
+                                        'src/Module/WebhostingModule' => ['url' => 'git@github.com:hubkit-sandbox/webhosting-module.git'],
+                                        'docs' => ['url' => 'git@github.com:hubkit-sandbox/docs.git'],
+                                        'noop' => ['url' => 'git@github.com:hubkit-sandbox/noop.git'],
+                                    ],
+                                ],
+                                '3.0' => [
+                                    'split' => [
+                                        'src/Module/CoreModule' => ['url' => 'git@github.com:hubkit-sandbox/core-module.git'],
+                                        'noop' => ['url' => false],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'hubkit-sandbox/differences' => [
+                            'branches' => [
+                                'master' => [
+                                    'sync-tags' => true,
+                                    'split' => [
+                                        'src/Module/CoreModule' => ['url' => 'git@github.com:hubkit-sandbox/core-module.git'],
+                                        'src/Module/WebhostingModule' => ['url' => 'git@github.com:hubkit-sandbox/webhosting-module.git'],
+                                        'docs' => ['url' => 'git@github.net:hubkit-sandbox/docs.git'],
+                                        'noop' => ['url' => 'git@github.net:hubkit-sandbox/noop.git'],
+                                        'bloop' => ['url' => 'git@github.org:hubkit-sandbox/weep.git'],
+                                    ],
+                                ],
+                                '2.x' => [
+                                    'sync-tags' => true,
+                                    'split' => [
+                                        'src/Module/CoreModule' => ['url' => 'git@github.com:hubkit-sandbox/core-module.git'],
+                                        'src/Module/WebhostingModule' => ['url' => 'git@github.com:hubkit-sandbox/webhosting-module.git'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'hubkit-sandbox/website' => [
+                            'branches' => [
+                                '1.0' => [
+                                    'sync-tags' => false,
+                                ],
+                                '2.x' => [
+                                    'sync-tags' => true,
+                                    'split' => [
+                                        'src/Module/CoreModule' => ['url' => false],
+                                        'src/Module/WebhostingModule' => ['url' => false],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $this->config->setActiveRepository('github.com', 'hubkit-sandbox/empire');
+    }
+
+    /** @test */
+    public function it_does_nothing_when_there_are_no_splits(): void
+    {
+        $this->github->getOrganization()->willReturn('hubkit-sandbox');
+        $this->github->getRepository()->willReturn('website');
+
+        $this->github->getRepoInfo('hubkit-sandbox', 'website')->willReturn(['private' => false]);
+        $this->config->setActiveRepository('github.com', 'hubkit-sandbox/empire');
+
+        $this->executeHandler();
+
+        $this->assertOutputMatches(
+            [
+                'Working on hubkit-sandbox/website (branch master)',
+                'No repository splits found, or splits are disabled for all branches.',
+            ]
+        );
+
+        $this->assertOutputNotMatches('The main repository is private, split repositories will be created as private.');
+    }
+
+    /** @test */
+    public function it_creates_split_repository_targets(): void
+    {
+        $this->expectRepoIsCreated('core-module');
+        $this->expectRepoIsCreated('webhosting-module');
+        $this->expectRepoIsCreated('docs');
+        $this->expectRepoIsCreated('noop');
+
+        $this->executeHandler();
+
+        $this->assertOutputMatches(
+            [
+                'Working on hubkit-sandbox/empire (branch master)',
+                'Repository https://github.com/hubkit-sandbox/core-module was created.',
+                'Repository https://github.com/hubkit-sandbox/webhosting-module was created.',
+                'Repository https://github.com/hubkit-sandbox/docs was created.',
+                'Repository https://github.com/hubkit-sandbox/noop was created.',
+                'Repository splits were created.',
+            ]
+        );
+
+        $this->assertOutputNotMatches('The main repository is private, split repositories will be created as private.');
+    }
+
+    /** @test */
+    public function it_creates_split_repository_targets_with_private(): void
+    {
+        $this->github->getRepoInfo('hubkit-sandbox', 'empire')->willReturn(['private' => true]);
+
+        $this->expectRepoIsCreated('core-module', public: false);
+        $this->expectRepoIsCreated('webhosting-module', public: false);
+        $this->expectRepoIsCreated('docs', public: false);
+        $this->expectRepoIsCreated('noop', public: false);
+
+        $this->executeHandler();
+
+        $this->assertOutputMatches(
+            [
+                'Working on hubkit-sandbox/empire (branch master)',
+                'The main repository is private, split repositories will be created as private.',
+                'Repository https://github.com/hubkit-sandbox/core-module was created.',
+                'Repository https://github.com/hubkit-sandbox/webhosting-module was created.',
+                'Repository https://github.com/hubkit-sandbox/docs was created.',
+                'Repository https://github.com/hubkit-sandbox/noop was created.',
+                'Repository splits were created.',
+            ]
+        );
+    }
+
+    /** @test */
+    public function it_creates_split_repository_targets_and_ignores_existing(): void
+    {
+        $this->expectRepoIsCreated('core-module');
+        $this->expectRepoExists('webhosting-module');
+        $this->expectRepoIsCreated('docs');
+        $this->expectRepoIsCreated('noop');
+
+        $this->executeHandler();
+
+        $this->assertOutputMatches(
+            [
+                'Working on hubkit-sandbox/empire (branch master)',
+                'Repository https://github.com/hubkit-sandbox/core-module was created.',
+                'Repository https://github.com/hubkit-sandbox/webhosting-module already exists.',
+                'Repository https://github.com/hubkit-sandbox/docs was created.',
+                'Repository https://github.com/hubkit-sandbox/noop was created.',
+                'Repository splits were created.',
+            ]
+        );
+        $this->assertOutputNotMatches('Repository https://github.com/hubkit-sandbox/webhosting-module was created.');
+    }
+
+    /** @test */
+    public function it_creates_split_repository_targets_and_ignores_existing_for_different_host(): void
+    {
+        $this->github->getRepository()->willReturn('differences');
+        $this->github->getRepoInfo('hubkit-sandbox', 'differences')->willReturn(['private' => false]);
+        $this->config->setActiveRepository('github.com', 'hubkit-sandbox/differences');
+
+        $this->expectRepoIsCreated('core-module');
+        $this->expectRepoExists('webhosting-module');
+        $this->expectForHost('github.net', ['hubkit-sandbox/docs'], ['hubkit-sandbox/noop']);
+        $this->expectForHost('github.org', [], ['hubkit-sandbox/weep']);
+
+        $this->executeHandler();
+
+        $this->assertOutputMatches(
+            [
+                'Working on hubkit-sandbox/differences (branch master)',
+                'Repository https://github.com/hubkit-sandbox/core-module was created.',
+                'Repository https://github.com/hubkit-sandbox/webhosting-module already exists.',
+                'Repository https://github.net/hubkit-sandbox/docs already exists.',
+                'Repository https://github.net/hubkit-sandbox/noop was created.',
+                'Repository https://github.org/hubkit-sandbox/weep was created.',
+                'Repository splits were created.',
+            ]
+        );
+        $this->assertOutputNotMatches('Repository https://github.com/hubkit-sandbox/webhosting-module was created.');
+    }
+
+    private function expectRepoIsCreated(string $name, string $organization = 'hubkit-sandbox', bool $public = true): void
+    {
+        $this->github->getRepoInfo('hubkit-sandbox', $name)->willThrow(new GitHubRuntimeException('Not Found', 404));
+        $this->github->createRepo($organization, $name, $public, false)->willReturn(
+            ['html_url' => sprintf('https://github.com/%s/%s', $organization, $name)]
+        );
+    }
+
+    private function expectRepoExists(string $name, string $organization = 'hubkit-sandbox'): void
+    {
+        $this->github->getRepoInfo($organization, $name)->will(static fn (array $a): array => ['html_url' => 'https://github.com/' . implode('/', $a)]);
+    }
+
+    /**
+     * @param array<int, string> $exists  ['org/name']
+     * @param array<int, string> $created ['org/name']
+     */
+    private function expectForHost(string $host, array $exists = [], array $created = [], bool $public = true): void
+    {
+        $prophecy = $this->prophesize(GitHub::class);
+        $prophecy->getHostname()->willReturn($host);
+
+        $prophecy->getRepoInfo(Argument::any(), Argument::any())->willThrow(new GitHubRuntimeException('Not Found', 404));
+        $prophecy->createRepo(Argument::any(), Argument::any(), Argument::any(), Argument::any())->will(static fn (array $a) => throw new \InvalidArgumentException(sprintf('Creation for %s/%s was not expected at host %s', $a[0], $a[1], $host)));
+
+        foreach ($exists as $repo) {
+            $prophecy->getRepoInfo(...explode('/', $repo))->willReturn(['html_url' => "https://{$host}/{$repo}"]);
+        }
+
+        foreach ($created as $repo) {
+            [$org, $name] = explode('/', $repo);
+            $prophecy->createRepo($org, $name, $public, false)->willReturn(['html_url' => "https://{$host}/{$repo}"]);
+        }
+
+        $this->github->createForHost($host)->willReturn($prophecy->reveal());
+    }
+
+    private function getArgs(): Args
+    {
+        return new Args(ArgsFormat::build()->getFormat(), new StringArgs(''));
+    }
+
+    private function executeHandler(): void
+    {
+        $handler = new SplitCreatedHandler(
+            $this->createStyle(),
+            $this->git->reveal(),
+            $this->github->reveal(),
+            $this->config,
+        );
+
+        $handler->handle($this->getArgs());
+    }
+}

--- a/tests/Handler/SplitRepoHandlerTest.php
+++ b/tests/Handler/SplitRepoHandlerTest.php
@@ -35,11 +35,6 @@ final class SplitRepoHandlerTest extends TestCase
     use ProphecyTrait;
     use SymfonyStyleTrait;
 
-    private const PR_NUMBER = 42;
-    private const PR_BRANCH = 'feature-something';
-    private const HEAD_SHA = '1b04532c8a09d9084abce36f8d9daf675f89eacc';
-    private const MERGE_SHA = '52a6bb3aeb7e08e8b641cfa679e4416096bf8439';
-
     private ObjectProphecy $git;
     private ObjectProphecy $github;
     private ObjectProphecy $splitshGit;

--- a/tests/Service/SplitshGitTest.php
+++ b/tests/Service/SplitshGitTest.php
@@ -49,7 +49,7 @@ final class SplitshGitTest extends TestCase
 
             $processCliProphecy = $this->prophesize(CliProcess::class);
             $processCliProphecy->mustRun([self::SPLITSH_EXECUTABLE, '--prefix', 'src/Bundle/CoreBundle'])->willReturn($this->getGitSplitShResult('2c00338aef823d0c0916fc1b59ef49d0bb76f02f'));
-            $processCliProphecy->mustRun(new Process(['git', 'push', 'origin', 'master:refs/heads/master'], '/tmp/hubkit/stor/_core'));
+            $processCliProphecy->mustRun(new Process(['git', 'push', 'origin', 'master:refs/heads/master'], '/tmp/hubkit/stor/_core'), 'If the destination does not exist run the `split-create` command.');
             $cliProcess = $processCliProphecy->reveal();
 
             $service = new SplitshGit($git, $cliProcess, $this->createMock(LoggerInterface::class), $gitTemp, self::SPLITSH_EXECUTABLE);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? |no
| Tickets       | 
| License       | MIT

Not entirely automatic, still requires the execution of a command but at least it doesn't require manually setting-up all the targets. Run the `split-create` command to create any missing destination, different hosts and organizations for split targets are supported.