### PR TITLE
Allow branch literal name like '1.x' as '#1.x'

### DIFF
--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -210,8 +210,8 @@ final class ConfigFactory
                             if (preg_match('{[\$\^]|/\w+$}', $name) > 0) {
                                 throw new \InvalidArgumentException(sprintf('Invalid regexp %s, cannot contain start/end anchor or options. Either "/[5-9]\.x/" not "/^[5-9].x$/i".', json_encode($name)));
                             }
-                        } elseif (preg_match('{^(:default|main|master|(\d+\.([x*]|\d+)))$}', $name) === 0) {
-                            throw new \InvalidArgumentException(sprintf('Invalid minor version or relative pattern %s, must be either: 1.x, 1.*, main, master, ":default" or a regexp like "/0.[1-9]+/".', json_encode($name)));
+                        } elseif (preg_match('{^(:default|main|master|(#\d+\.x)|(\d+\.([x*]|\d+)))$}', $name) === 0) {
+                            throw new \InvalidArgumentException(sprintf('Invalid version or relative pattern %s, must be either "1.x" or "1.*", or "#1.x" (for an exact branch named 1.x), ":default", "main" or "master", or a regexp like "/0.[1-9]+/".', json_encode($name)));
                         }
                     }
 

--- a/tests/ConfigFactoryTest.php
+++ b/tests/ConfigFactoryTest.php
@@ -191,6 +191,20 @@ final class ConfigFactoryTest extends TestCase
                                     'ignore-default' => true,
                                     'maintained' => false,
                                 ],
+
+                                // Literal branch name, no pattern
+                                '#11.x' => [
+                                    'sync-tags' => false,
+                                    'split' => [
+                                        'doc' => [
+                                            'url' => 'git@github.com:park-manager/doc2.git',
+                                            'sync-tags' => false,
+                                        ],
+                                    ],
+                                    'upmerge' => false,
+                                    'ignore-default' => true,
+                                    'maintained' => true,
+                                ],
                             ],
                         ],
                     ],
@@ -329,9 +343,9 @@ final class ConfigFactoryTest extends TestCase
      */
     public function provideInvalidConfigs(): iterable
     {
-        yield 'branches: non versioned branch' => ['invalid_branch_name.php', 'Invalid configuration for path "hubkit.repositories.github.com.repos.park-manager/park-manager.branches": Invalid minor version or relative pattern "nee", must be either: 1.x, 1.*, main, master, ":default" or a regexp like "/0.[1-9]+/".'];
-        yield 'branches: v prefix' => ['invalid_branch_pattern.php', 'Invalid configuration for path "hubkit.repositories.github.com.repos.park-manager/park-manager.branches": Invalid minor version or relative pattern "v2.0", must be either: 1.x, 1.*, main, master, ":default" or a regexp like "/0.[1-9]+/".'];
-        yield 'branches: wildcard for major' => ['invalid_branch_pattern2.php', 'Invalid configuration for path "hubkit.repositories.github.com.repos.park-manager/park-manager.branches": Invalid minor version or relative pattern "x.0", must be either: 1.x, 1.*, main, master, ":default" or a regexp like "/0.[1-9]+/".'];
+        yield 'branches: non versioned branch' => ['invalid_branch_name.php', 'Invalid configuration for path "hubkit.repositories.github.com.repos.park-manager/park-manager.branches": Invalid version or relative pattern "nee", must be either "1.x" or "1.*", or "#1.x" (for an exact branch named 1.x), ":default", "main" or "master", or a regexp like "/0.[1-9]+/".'];
+        yield 'branches: v prefix' => ['invalid_branch_pattern.php', 'Invalid configuration for path "hubkit.repositories.github.com.repos.park-manager/park-manager.branches": Invalid version or relative pattern "v2.0", must be either "1.x" or "1.*", or "#1.x" (for an exact branch named 1.x), ":default", "main" or "master", or a regexp like "/0.[1-9]+/".'];
+        yield 'branches: wildcard for major' => ['invalid_branch_pattern2.php', 'Invalid configuration for path "hubkit.repositories.github.com.repos.park-manager/park-manager.branches": Invalid version or relative pattern "x.0", must be either "1.x" or "1.*", or "#1.x" (for an exact branch named 1.x), ":default", "main" or "master", or a regexp like "/0.[1-9]+/".'];
         yield 'branches: invalid regexp' => ['invalid_branch_regexp.php', 'Invalid configuration for path "hubkit.repositories.github.com.repos.park-manager/park-manager.branches": Invalid regexp "\/[]\/" error: "preg_match(): Compilation failed: missing terminating ] for character class at offset 2".'];
         yield 'branches: regexp with options' => ['invalid_branch_regexp2.php', 'Invalid configuration for path "hubkit.repositories.github.com.repos.park-manager/park-manager.branches": Invalid regexp "\/\\\\d\\\\.\\\\d+\/s", cannot contain start/end anchor or options. Either "/[5-9]\.x/" not "/^[5-9].x$/i".'];
         yield 'branches: regexp with anchors' => ['invalid_branch_regexp3.php', 'Invalid configuration for path "hubkit.repositories.github.com.repos.park-manager/park-manager.branches": Invalid regexp "\/^\\\\d\\\\.\\\\d+$\/", cannot contain start/end anchor or options. Either "/[5-9]\.x/" not "/^[5-9].x$/i".'];

--- a/tests/Fixtures/config/schema_v2_global/config2.php
+++ b/tests/Fixtures/config/schema_v2_global/config2.php
@@ -47,6 +47,20 @@ return [
 
                         // Marked as unmaintained
                         '10.0' => false,
+
+                        // Literal branch name, no pattern
+                        '#11.x' => [
+                            'sync-tags' => false,
+                            'split' => [
+                                'doc' => [
+                                    'url' => 'git@github.com:park-manager/doc2.git',
+                                    'sync-tags' => false,
+                                ],
+                            ],
+                            'upmerge' => false,
+                            'ignore-default' => true,
+                            'maintained' => true,
+                        ],
                     ],
                 ],
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

This was already supported in the `Config` class but the ConfigFactory didn't allow for the `#1.x` pattern yet.

