### PR TITLE
Fix repository splitting not working for with empty target repository

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -586,6 +586,61 @@ parameters:
 			path: tests/Functional/Service/Git/GitFileReaderTest.php
 
 		-
+			message: "#^Method HubKit\\\\Tests\\\\Functional\\\\Service\\\\Git\\\\GitTempRepositoryTest\\:\\:getTempDir\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Service/Git/GitTempRepositoryTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Functional\\\\Service\\\\Git\\\\GitTempRepositoryTest\\:\\:givenLocalBranchesExist\\(\\) has parameter \\$branches with no value type specified in iterable type iterable\\.$#"
+			count: 1
+			path: tests/Functional/Service/Git/GitTempRepositoryTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$directory of function chdir expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Functional/Service/Git/GitTempRepositoryTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of class Symfony\\\\Component\\\\Console\\\\Output\\\\StreamOutput constructor expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/Functional/Service/Git/GitTempRepositoryTest.php
+
+		-
+			message: "#^Property HubKit\\\\Tests\\\\Functional\\\\Service\\\\Git\\\\GitTempRepositoryTest\\:\\:\\$origCwd \\(string\\|null\\) does not accept string\\|false\\.$#"
+			count: 1
+			path: tests/Functional/Service/Git/GitTempRepositoryTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Functional\\\\Service\\\\Git\\\\SplitshGitTest\\:\\:getTempDir\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Service/Git/SplitshGitTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Functional\\\\Service\\\\Git\\\\SplitshGitTest\\:\\:givenLocalBranchesExist\\(\\) has parameter \\$branches with no value type specified in iterable type iterable\\.$#"
+			count: 1
+			path: tests/Functional/Service/Git/SplitshGitTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$directory of function chdir expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Functional/Service/Git/SplitshGitTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of class Symfony\\\\Component\\\\Console\\\\Output\\\\StreamOutput constructor expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/Functional/Service/Git/SplitshGitTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$targets of method HubKit\\\\Service\\\\SplitshGit\\:\\:syncTags\\(\\) expects array\\<int\\|string, array\\{string, string, string\\}\\>, non\\-empty\\-array\\<int, array\\{string, string, string\\}\\|null\\> given\\.$#"
+			count: 1
+			path: tests/Functional/Service/Git/SplitshGitTest.php
+
+		-
+			message: "#^Property HubKit\\\\Tests\\\\Functional\\\\Service\\\\Git\\\\SplitshGitTest\\:\\:\\$origCwd \\(string\\|null\\) does not accept string\\|false\\.$#"
+			count: 1
+			path: tests/Functional/Service/Git/SplitshGitTest.php
+
+		-
 			message: "#^Parameter \\#1 \\$git of class HubKit\\\\Cli\\\\Handler\\\\BranchAliasHandler constructor expects HubKit\\\\Service\\\\Git, object given\\.$#"
 			count: 1
 			path: tests/Handler/BranchAliasHandlerTest.php
@@ -1797,6 +1852,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$directory of function chdir expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Service/SplitshGitTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$targets of method HubKit\\\\Service\\\\SplitshGit\\:\\:syncTags\\(\\) expects array\\<int\\|string, array\\{string, string, string\\}\\>, array\\{/tmp/hubkit/stor/_core\\: array\\{'2c00338aef823d0c091…', 'git@github\\.com\\:park…', 5\\}, /tmp/hubkit/stor/_user\\: array\\{'3eed8083737422fe9ac…', 'git@github\\.com\\:park…', 3\\}\\} given\\.$#"
 			count: 1
 			path: tests/Service/SplitshGitTest.php
 

--- a/src/Service/Git/GitTempRepository.php
+++ b/src/Service/Git/GitTempRepository.php
@@ -69,7 +69,13 @@ class GitTempRepository
             return;
         }
 
-        $this->process->mustRun(new Process(['git', 'checkout', 'remotes/origin/' . $branchName, '-b', $branchName], $directory));
+        $process = $this->process->run(new Process(['git', 'checkout', 'remotes/origin/' . $branchName, '-b', $branchName], $directory));
+
+        // Either remote branch doesn't exist or no commits found yet, checkout a 'new'
+        // branch by name instead. If this branch exists in the future it's reset anyway.
+        if (! $process->isSuccessful()) {
+            $this->process->mustRun(new Process(['git', 'checkout', '-b', $branchName], $directory));
+        }
     }
 
     private function branchExists(string $directory, string $branch): bool

--- a/tests/Functional/Service/Git/GitTempRepositoryTest.php
+++ b/tests/Functional/Service/Git/GitTempRepositoryTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HuPKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Tests\Functional\Service\Git;
+
+use HubKit\Service\Filesystem;
+use HubKit\Service\Git\GitTempRepository;
+use HubKit\Tests\Functional\GitTesterTrait;
+use HubKit\Tests\Functional\TestCliProcess;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * @internal
+ */
+final class GitTempRepositoryTest extends TestCase
+{
+    use GitTesterTrait;
+
+    private ?string $origCwd = null;
+    private string $rootRepository;
+
+    private Filesystem $filesystem;
+    private TestCliProcess $cliProcess;
+    private GitTempRepository $gitTempRepository;
+
+    /** @before */
+    public function setUpLocalRepository(): void
+    {
+        $this->origCwd = getcwd();
+
+        $tempDir = $this->getTempDir();
+        $this->cwd = $this->rootRepository = $this->createGitDirectory($tempDir . '/root');
+        $this->commitFileToRepository('foo.txt', $this->rootRepository, 'foo.txt in master on root');
+        $this->runCliCommand(['git', 'checkout', '-b', '_hubkit']);
+        $this->commitFileToRepository('config.php', $this->rootRepository, 'config.php in _hubkit on root');
+        $this->runCliCommand(['git', 'checkout', 'master']);
+
+        $this->cwd = $this->rootRepository;
+
+        $this->filesystem ??= new Filesystem($tempDir);
+        $this->cliProcess = $this->getProcessService($this->rootRepository);
+        $this->cliProcess->ignoreCwdChangeWhen(static fn (string $val): bool => str_contains($val, '/hubkit/stor/repo_'));
+
+        $this->gitTempRepository ??= new GitTempRepository($this->cliProcess, $this->filesystem);
+    }
+
+    /** @after */
+    public function restoreCwd(): void
+    {
+        chdir($this->origCwd);
+        $this->filesystem->clearTempFiles();
+    }
+
+    /** @test */
+    public function it_creates_temporary_repository(): void
+    {
+        $location = $this->gitTempRepository->getLocal($this->rootRepository);
+
+        self::assertFileExists($location . '/.git');
+        // Not checked out yet, so directory is bare
+        self::assertFileDoesNotExist($location . '/foo.txt');
+        self::assertFileDoesNotExist($location . '/config.php');
+
+        $location2 = $this->gitTempRepository->getLocal($this->rootRepository);
+
+        self::assertEquals($location, $location2);
+    }
+
+    /** @test */
+    public function it_creates_temporary_repository_for_specific_branch(): void
+    {
+        $location = $this->gitTempRepository->getLocal($this->rootRepository, 'master');
+
+        self::assertFileExists($location . '/.git');
+        self::assertFileExists($location . '/foo.txt');
+        self::assertFileDoesNotExist($location . '/config.php');
+
+        // Repository already exists, but no specific branch was given
+        $location2 = $this->gitTempRepository->getLocal($this->rootRepository);
+
+        self::assertEquals($location, $location2);
+        self::assertFileExists($location . '/.git');
+        self::assertFileExists($location . '/foo.txt');
+    }
+
+    /** @test */
+    public function it_updates_temporary_repository_for_specific_branch(): void
+    {
+        $location = $this->gitTempRepository->getLocal($this->rootRepository, 'master');
+
+        self::assertFileExists($location . '/.git');
+        self::assertFileExists($location . '/foo.txt');
+        self::assertFileDoesNotExist($location . '/config.php');
+
+        $this->commitFileToRepository('config.php', $this->rootRepository, 'config.php in master on root');
+
+        // Repository already exists, update it
+        $location2 = $this->gitTempRepository->getLocal($this->rootRepository, 'master');
+
+        self::assertEquals($location, $location2);
+        self::assertFileExists($location . '/config.php');
+    }
+
+    /** @test */
+    public function it_creates_temporary_repository_with_different_specific_branch(): void
+    {
+        $location = $this->gitTempRepository->getLocal($this->rootRepository, 'master');
+
+        self::assertFileExists($location . '/.git');
+        self::assertFileExists($location . '/foo.txt');
+        self::assertFileDoesNotExist($location . '/config.php');
+
+        // Repository already exists, but different branch was provided
+        $location2 = $this->gitTempRepository->getLocal($this->rootRepository, '_hubkit');
+
+        self::assertEquals($location, $location2);
+        self::assertFileExists($location . '/.git');
+        self::assertFileExists($location . '/foo.txt');
+        self::assertFileExists($location . '/config.php');
+    }
+
+    /** @test */
+    public function it_supports_being_pushed_to(): void
+    {
+        $location = $this->gitTempRepository->getLocal($this->rootRepository, 'master');
+        $this->commitFileToRepository('foo2.txt', $this->rootRepository, 'foo2.txt in master on root');
+
+        self::assertFileDoesNotExist($location . '/foo2.txt');
+
+        $this->cliProcess->mustRun(new Process(['git', 'push', $location, 'master:refs/heads/master'], $this->rootRepository));
+        $this->cliProcess->mustRun(new Process(['git', 'reset', '--hard'], $location));
+
+        self::assertFileExists($location . '/foo2.txt');
+    }
+}

--- a/tests/Functional/Service/Git/SplitshGitTest.php
+++ b/tests/Functional/Service/Git/SplitshGitTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HuPKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Tests\Functional\Service\Git;
+
+use HubKit\Service\Filesystem;
+use HubKit\Service\Git\GitBase;
+use HubKit\Service\Git\GitTempRepository;
+use HubKit\Service\SplitshGit;
+use HubKit\StringUtil;
+use HubKit\Tests\Functional\GitTesterTrait;
+use HubKit\Tests\Functional\TestCliProcess;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\Process;
+
+/**
+ * @internal
+ */
+final class SplitshGitTest extends TestCase
+{
+    use GitTesterTrait;
+
+    private ?string $origCwd = null;
+    private string $rootRepository;
+
+    private GitBase $git;
+    private Filesystem $filesystem;
+    private TestCliProcess $cliProcess;
+    private GitTempRepository $gitTempRepository;
+    private SplitshGit $splitshGit;
+
+    /** @before */
+    public function setUpLocalRepository(): void
+    {
+        $this->origCwd = getcwd();
+        $executable = (new ExecutableFinder())->find('splitsh-lite');
+
+        if ($executable === null) {
+            self::markTestSkipped('Could not find "splitsh-lite" in your "$PATH" environment.');
+        }
+
+        $tempDir = $this->getTempDir();
+        $this->cwd = $this->rootRepository = $this->createGitDirectory($tempDir . '/root');
+        chdir($this->cwd);
+
+        $this->commitFileToRepository('lib/core/index.php', $this->rootRepository);
+        $this->commitFileToRepository('lib/core/main.php', $this->rootRepository);
+        $this->commitFileToRepository('lib/validator/constraints.php', $this->rootRepository);
+        $this->commitFileToRepository('lib/validator/main.php', $this->rootRepository);
+        $this->commitFileToRepository('docs/main.rst', $this->rootRepository);
+        $this->commitFileToRepository('docs/core.rst', $this->rootRepository);
+
+        $this->createGitDirectory($tempDir . '/split-core');
+        $this->createGitDirectory($tempDir . '/split-docs');
+        $this->createGitDirectory($tempDir . '/split-validator');
+        $this->createGitDirectory($tempDir . '/split-doctrine');
+
+        $this->filesystem = new Filesystem($tempDir);
+        $this->cliProcess = $this->getProcessService($this->rootRepository);
+        $this->cliProcess->ignoreCwdChangeWhen(static fn (string $val): bool => true);
+
+        $this->gitTempRepository = new GitTempRepository($this->cliProcess, $this->filesystem);
+        $this->git = new GitBase($this->cliProcess, $this->cwd);
+
+        $this->splitshGit = new SplitshGit(
+            $this->git,
+            $this->cliProcess,
+            new NullLogger(), // XXX Should use BufferingLogger
+            $this->gitTempRepository,
+            $executable
+        );
+    }
+
+    /** @after */
+    public function restoreCwd(): void
+    {
+        chdir($this->origCwd);
+
+        if (isset($this->filesystem)) {
+            $this->filesystem->clearTempFiles();
+        }
+    }
+
+    /** @test */
+    public function it_splits_at_prefix(): void
+    {
+        $tempDir = $this->getTempDir();
+
+        self::assertNotNull($this->splitshGit->splitTo('master', 'lib/core', 'file://' . $tempDir . '/split-core'));
+        self::assertNotNull($this->splitshGit->splitTo('master', 'lib/validator', 'file://' . $tempDir . '/split-validator'));
+        self::assertNotNull($this->splitshGit->splitTo('master', 'docs', 'file://' . $tempDir . '/split-docs'));
+        self::assertNull($this->splitshGit->splitTo('master', 'doctrine', 'file://' . $tempDir . '/split-doctrine'));
+
+        // Refs were updated but not HEAD not
+        $this->runCliCommand(['git', 'reset', '--hard'], $tempDir . '/split-core');
+        $this->runCliCommand(['git', 'reset', '--hard'], $tempDir . '/split-validator');
+        $this->runCliCommand(['git', 'reset', '--hard'], $tempDir . '/split-docs');
+
+        self::assertFileExists($tempDir . '/split-core/index.php');
+        self::assertFileExists($tempDir . '/split-core/main.php');
+        self::assertFileDoesNotExist($tempDir . '/split-core/main.rst');
+
+        self::assertFileExists($tempDir . '/split-validator/constraints.php');
+        self::assertFileExists($tempDir . '/split-validator/main.php');
+        self::assertFileDoesNotExist($tempDir . '/split-validator/index.php');
+
+        self::assertFileExists($tempDir . '/split-docs/main.rst');
+        self::assertFileExists($tempDir . '/split-docs/core.rst');
+    }
+
+    /** @test */
+    public function it_syncs_tags(): void
+    {
+        $tempDir = $this->getTempDir();
+
+        $this->assertRepositoryTagsEquals([], $tempDir . '/split-core');
+        $this->assertRepositoryTagsEquals([], $tempDir . '/split-validator');
+        $this->assertRepositoryTagsEquals([], $tempDir . '/split-docs');
+
+        /** @var array<int, array{0: string, 1: string, 2: string}> $splits */
+        $splits = [];
+        $splits[] = $this->splitshGit->splitTo('master', 'lib/core', 'file://' . $tempDir . '/split-core');
+        $splits[] = $this->splitshGit->splitTo('master', 'lib/validator', 'file://' . $tempDir . '/split-validator');
+        $splits[] = $this->splitshGit->splitTo('master', 'docs', 'file://' . $tempDir . '/split-docs');
+
+        // Refs were updated but not HEAD not
+        $this->runCliCommand(['git', 'reset', '--hard'], $tempDir . '/split-core');
+        $this->runCliCommand(['git', 'reset', '--hard'], $tempDir . '/split-validator');
+        $this->runCliCommand(['git', 'reset', '--hard'], $tempDir . '/split-docs');
+
+        $this->splitshGit->syncTags('1.0.0', 'master', $splits);
+
+        $this->assertRepositoryTagsEquals(['v1.0.0'], $tempDir . '/split-core');
+        $this->assertRepositoryTagsEquals(['v1.0.0'], $tempDir . '/split-validator');
+        $this->assertRepositoryTagsEquals(['v1.0.0'], $tempDir . '/split-docs');
+    }
+
+    /**
+     * @param string[] $expected
+     */
+    private function assertRepositoryTagsEquals(array $expected, string $repository): void
+    {
+        $tags = StringUtil::splitLines($this->cliProcess->mustRun(new Process(['git', 'tag', '--list'], $repository))->getOutput());
+
+        self::assertEquals($expected, $tags);
+    }
+}

--- a/tests/Service/SplitshGitTest.php
+++ b/tests/Service/SplitshGitTest.php
@@ -50,6 +50,7 @@ final class SplitshGitTest extends TestCase
             $processCliProphecy = $this->prophesize(CliProcess::class);
             $processCliProphecy->mustRun([self::SPLITSH_EXECUTABLE, '--prefix', 'src/Bundle/CoreBundle'])->willReturn($this->getGitSplitShResult('2c00338aef823d0c0916fc1b59ef49d0bb76f02f'));
             $processCliProphecy->mustRun(new Process(['git', 'push', 'origin', 'master:refs/heads/master'], '/tmp/hubkit/stor/_core'), 'If the destination does not exist run the `split-create` command.');
+            $processCliProphecy->mustRun(new Process(['git', 'reset', '--hard'], '/tmp/hubkit/stor/_core'));
             $cliProcess = $processCliProphecy->reveal();
 
             $service = new SplitshGit($git, $cliProcess, $this->createMock(LoggerInterface::class), $gitTemp, self::SPLITSH_EXECUTABLE);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | Fix #132 
| License       | MIT

During the initial split the target repository is still empty and no branch exists, checkout the branch by name instead.

Add tests to ensure this works and doesn't break in the future (requires Splitsh-lite is installed)

