### PR TITLE
Allow to set the main-branch

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -88,6 +88,12 @@ return [
     'host' => 'github.com',
     'repository' => 'organization/repository-name',
     
+    // Since v1.3 - which branch is considered the main branch. Either: 'main', 'master', '2.0', or 'trunk'
+    // This configuration is used (among) for upmerging as know the last branch in the list.
+    //
+    // If not set this is automatically guessed at application boot, in v2.0 this will default to 'main'.  
+    //'main_branch' => null,
+    
      // See branches section below for supported configuration 
     'branches' => [],
 ];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -141,6 +141,11 @@ parameters:
 			path: src/Config.php
 
 		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Style\\\\StyleInterface\\:\\:block\\(\\)\\.$#"
+			count: 1
+			path: src/ConfigFactory.php
+
+		-
 			message: "#^Method HubKit\\\\ConfigFactory\\:\\:normalizePath\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/ConfigFactory.php
@@ -871,27 +876,27 @@ parameters:
 			path: tests/Handler/EditConfigHandlerTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$git of class class@anonymous/tests/Handler/EditConfigHandlerTest\\.php\\:225 constructor expects HubKit\\\\Service\\\\Git, object given\\.$#"
+			message: "#^Parameter \\#2 \\$git of class class@anonymous/tests/Handler/EditConfigHandlerTest\\.php\\:223 constructor expects HubKit\\\\Service\\\\Git, object given\\.$#"
 			count: 1
 			path: tests/Handler/EditConfigHandlerTest.php
 
 		-
-			message: "#^Parameter \\#3 \\$github of class class@anonymous/tests/Handler/EditConfigHandlerTest\\.php\\:225 constructor expects HubKit\\\\Service\\\\GitHub, object given\\.$#"
+			message: "#^Parameter \\#3 \\$github of class class@anonymous/tests/Handler/EditConfigHandlerTest\\.php\\:223 constructor expects HubKit\\\\Service\\\\GitHub, object given\\.$#"
 			count: 1
 			path: tests/Handler/EditConfigHandlerTest.php
 
 		-
-			message: "#^Parameter \\#5 \\$filesystem of class class@anonymous/tests/Handler/EditConfigHandlerTest\\.php\\:225 constructor expects HubKit\\\\Service\\\\Filesystem, object given\\.$#"
+			message: "#^Parameter \\#5 \\$filesystem of class class@anonymous/tests/Handler/EditConfigHandlerTest\\.php\\:223 constructor expects HubKit\\\\Service\\\\Filesystem, object given\\.$#"
 			count: 1
 			path: tests/Handler/EditConfigHandlerTest.php
 
 		-
-			message: "#^Parameter \\#6 \\$tempRepository of class class@anonymous/tests/Handler/EditConfigHandlerTest\\.php\\:225 constructor expects HubKit\\\\Service\\\\Git\\\\GitTempRepository, object given\\.$#"
+			message: "#^Parameter \\#6 \\$tempRepository of class class@anonymous/tests/Handler/EditConfigHandlerTest\\.php\\:223 constructor expects HubKit\\\\Service\\\\Git\\\\GitTempRepository, object given\\.$#"
 			count: 1
 			path: tests/Handler/EditConfigHandlerTest.php
 
 		-
-			message: "#^Parameter \\#7 \\$finder of class class@anonymous/tests/Handler/EditConfigHandlerTest\\.php\\:225 constructor expects Symfony\\\\Component\\\\Finder\\\\Finder, object given\\.$#"
+			message: "#^Parameter \\#7 \\$finder of class class@anonymous/tests/Handler/EditConfigHandlerTest\\.php\\:223 constructor expects Symfony\\\\Component\\\\Finder\\\\Finder, object given\\.$#"
 			count: 1
 			path: tests/Handler/EditConfigHandlerTest.php
 

--- a/src/Cli/Handler/SwitchBaseHandler.php
+++ b/src/Cli/Handler/SwitchBaseHandler.php
@@ -130,7 +130,7 @@ final class SwitchBaseHandler extends GitBaseHandler
         $activeBranch = $this->git->getActiveBranchName();
 
         if ($activeBranch[0] === '_') {
-            $activeBranch = $this->git->getPrimaryBranch();
+            $activeBranch = $this->config->getMainBranch();
         }
 
         // Always (re)start the rebase process from scratch in case something went horrible wrong.

--- a/src/Cli/Handler/TakeHandler.php
+++ b/src/Cli/Handler/TakeHandler.php
@@ -35,7 +35,7 @@ final class TakeHandler extends GitBaseHandler
         }
 
         $slugTitle = StringUtil::slugify(sprintf('%s %s', $issue['number'], $issue['title']));
-        $base = $args->getOption('base') ?? $this->git->getPrimaryBranch();
+        $base = $args->getOption('base') ?? $this->config->getMainBranch();
 
         $this->guardMaintained($base);
 

--- a/src/Cli/Handler/UpMergeHandler.php
+++ b/src/Cli/Handler/UpMergeHandler.php
@@ -96,7 +96,7 @@ final class UpMergeHandler extends GitBaseHandler
      */
     private function getBranches(string $branch, array $branches): array
     {
-        $defaultBranch = $this->github->getDefaultBranch();
+        $defaultBranch = $this->config->getMainBranch();
 
         if (! \in_array($defaultBranch, $branches, true)) {
             $branches[] = $defaultBranch;

--- a/src/Config.php
+++ b/src/Config.php
@@ -205,6 +205,11 @@ final class Config
         );
     }
 
+    public function getMainBranch(): string
+    {
+        return $this->getFirstNotNull([['_local', 'main_branch'], ['_main_branch']], 'main');
+    }
+
     /**
      * @param array<string, mixed> $default
      * @param array<string, mixed> $config

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace HubKit;
 
+use HubKit\Service\Git;
 use HubKit\Service\Git\GitFileReader;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -31,6 +32,7 @@ final class ConfigFactory
         string $configFile,
         private readonly StyleInterface $style,
         private readonly GitFileReader $gitFileReader,
+        private readonly Git $git,
     ) {
         $this->currentDir = self::normalizePath($currentDir);
         $this->configFile = self::normalizePath($configFile);
@@ -81,6 +83,15 @@ final class ConfigFactory
             }
 
             $config['_local'] = $this->resolveLocalConfig($localeConfig);
+        }
+
+        if (! isset($config['_local']['main_branch'])) {
+            // No local configuration provided, but still the main-branch must be resolvable
+            // So store it here, there is no expectation to explicitly get this for a repository.
+            //
+            // In the future the whole concept for using 'global' configuration for a repository
+            // might be dropped in favor of local-only configuration.
+            $config['_main_branch'] = $this->findMainBranch();
         }
 
         $config['current_dir'] = $this->currentDir;
@@ -161,7 +172,7 @@ final class ConfigFactory
         try {
             return (new Processor())->process($treeBuilder->buildTree(), [$config]);
         } catch (ConfigException $e) {
-            throw new \RuntimeException('Configuration contains one or more errors: ' . $e->getMessage(), 1, $e);
+            throw new \RuntimeException('Configuration contains one or more errors. ' . $e->getMessage(), 1, $e);
         }
     }
 
@@ -267,13 +278,14 @@ final class ConfigFactory
      *
      * @return array<string, mixed>
      */
-    private function resolveLocalConfig(array $config): array
+    public function resolveLocalConfig(array $config): array
     {
         $treeBuilder = new TreeBuilder('hubkit');
         $treeBuilder->getRootNode()
             ->ignoreExtraKeys(false)
             ->children()
                 ->integerNode('schema_version')
+                    ->isRequired()
                     ->min(2)
                     ->max(2)
                 ->end()
@@ -284,13 +296,72 @@ final class ConfigFactory
                 ->end()
                 ->scalarNode('host')->defaultNull()->end()
                 ->scalarNode('repository')->defaultNull()->end()
+                ->scalarNode('main_branch')
+                    ->defaultNull()
+                    ->validate()
+                        ->always(function ($v) {
+                            if ($v === null) {
+                                return $this->findMainBranch();
+                            }
+
+                            $v = (string) $v;
+
+                            if (mb_strtoupper($v) === 'HEAD') {
+                                throw new \InvalidArgumentException('Cannot use Git ref HEAD as branch name.');
+                            }
+
+                            if (preg_match('{^(heads|tags|remotes|notes)/}i', $v) === 1) {
+                                throw new \InvalidArgumentException('Cannot start with Git refs (heads, tags, remotes, notes)/.');
+                            }
+
+                            if (preg_match('{^([\p{L}\p{N}]+([./_-]?[\p{L}\p{N}]+)?)+$}ui', $v) !== 1) {
+                                throw new \InvalidArgumentException('Invalid name provided, must follow the Git convention for branch names.');
+                            }
+
+                            return $v;
+                        })
+                    ->end()
+                ->end()
             ->end()
         ;
 
         try {
             return (new Processor())->process($treeBuilder->buildTree(), [$config]);
         } catch (ConfigException $e) {
-            throw new \RuntimeException('Local configuration contains one or more errors: ' . $e->getMessage(), 1, $e);
+            throw new \RuntimeException('Local configuration contains one or more errors. ' . $e->getMessage(), 1, $e);
         }
+    }
+
+    private function findMainBranch(): string
+    {
+        if ($this->git->branchExists('main')) {
+            $branch = 'main';
+        } elseif ($this->git->branchExists('master')) {
+            $branch = 'master';
+        } else {
+            $versions = $this->git->getVersionBranches();
+            /** @var string|null $branch */
+            $branch = array_pop($versions);
+
+            if ($branch === null) {
+                try {
+                    $branch = $this->git->getActiveBranchName();
+                } catch (\Throwable $e) {
+                    $this->style->error([
+                        'Could not detect "main_branch", neither "main", "master" or any versioned branch exist, defaulting to "main".',
+                        $e->getMessage(),
+                    ]);
+
+                    return 'main';
+                }
+            }
+        }
+
+        $this->style->block([
+            'No "main_branch" was not set, this value will default to "main" in HuPKit v2.0.' . "\n" .
+            sprintf('The "main_branch" is resolved as "%s", set the "main_branch" option in your local configuration to change this.', $branch),
+        ], null, 'fg=yellow', ' ! ');
+
+        return $branch;
     }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -28,7 +28,8 @@ class Container extends \Pimple\Container implements ContainerInterface
             $container['current_dir'],
             $container['config_file'],
             $container['style'],
-            $container['git.file_reader']
+            $container['git.file_reader'],
+            $container['git'],
         ))->create();
 
         $this['guzzle'] = static function (self $container) {

--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -105,7 +105,11 @@ class Git
         return $activeBranch;
     }
 
-    /** @return string either main, master or a custom configured branch-name */
+    /**
+     * @deprecated use {@see Config::getMainBranch()} instead
+     *
+     * @return string either main, master or a custom configured branch-name
+     */
     public function getPrimaryBranch(): string
     {
         static $branch = null;
@@ -135,13 +139,19 @@ class Git
     }
 
     /** @return array<int, string> ['v1.0', 'v1.5', 'v2.0' '...'] */
-    public function getVersionBranches(string $remote): array
+    public function getVersionBranches(?string $remote = null): array
     {
-        $branches = StringUtil::splitLines(
-            $this->process->mustRun(
-                ['git', 'for-each-ref', '--format', '%(refname:strip=3)', 'refs/remotes/' . $remote]
-            )->getOutput()
-        );
+        if ($remote) {
+            $branches = StringUtil::splitLines(
+                $this->process->mustRun(
+                    ['git', 'for-each-ref', '--format', '%(refname:strip=3)', 'refs/remotes/' . $remote]
+                )->getOutput()
+            );
+        } else {
+            $branches = StringUtil::splitLines(
+                $this->process->mustRun(['git', 'for-each-ref', '--format', '%(refname:short)', 'refs/heads/'])->getOutput()
+            );
+        }
 
         $branches = array_filter($branches, static fn (string $branch) => preg_match('/^v?' . Version::VERSION_REGEX . '$/i', $branch) || preg_match('/^v?(?P<major>\d++)\.(?P<rel>x)$/', $branch));
 

--- a/tests/ConfigFactoryTest.php
+++ b/tests/ConfigFactoryTest.php
@@ -15,9 +15,11 @@ namespace HubKit\Tests;
 
 use HubKit\Config;
 use HubKit\ConfigFactory;
+use HubKit\Service\Git;
 use HubKit\Service\Git\GitFileReader;
 use HubKit\Tests\Handler\SymfonyStyleTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
@@ -64,15 +66,17 @@ final class ConfigFactoryTest extends TestCase
                 ],
             ],
             'current_dir' => __DIR__ . '/Fixtures/config/schema_v1_local',
+            '_main_branch' => 'main',
         ]);
 
         self::assertEquals(
             $config,
-            (new ConfigFactory(
+            $resolved = (new ConfigFactory(
                 __DIR__ . '/Fixtures/config/schema_v1_local',
                 __DIR__ . '/Fixtures/config/schema_v1_global/config.php',
                 $this->createStyle(),
-                $this->getGitFileReaderWithNotExistentFile()
+                $this->getGitFileReaderWithNotExistentFile(),
+                $this->getGit(),
             ))->create()
         );
 
@@ -123,17 +127,20 @@ final class ConfigFactoryTest extends TestCase
                 ],
             ],
             'current_dir' => __DIR__ . '/Fixtures/config/schema_v1_local',
+            '_main_branch' => 'main',
         ]);
 
         self::assertEquals(
             $config,
-            (new ConfigFactory(
+            $resolved = (new ConfigFactory(
                 __DIR__ . '/Fixtures/config/schema_v1_local',
                 __DIR__ . '/Fixtures/config/schema_v1n_global/config.php',
                 $this->createStyle(),
-                $this->getGitFileReaderWithNotExistentFile()
+                $this->getGitFileReaderWithNotExistentFile(),
+                $this->getGit(),
             ))->create()
         );
+        self::assertEquals('main', $resolved->getMainBranch());
 
         $this->assertOutputMatches('Hubkit "schema_version" 1 in configuration is deprecated and will no longer work in v2.0.');
     }
@@ -211,19 +218,307 @@ final class ConfigFactoryTest extends TestCase
                 ],
             ],
             'current_dir' => __DIR__ . '/Fixtures/config/schema_v2_global',
+            '_main_branch' => 'main',
         ]);
 
         self::assertEquals(
             $config,
-            (new ConfigFactory(
+            $resolved = (new ConfigFactory(
                 __DIR__ . '/Fixtures/config/schema_v2_global',
                 __DIR__ . '/Fixtures/config/schema_v2_global/config2.php',
                 $this->createStyle(),
-                $this->getGitFileReaderWithNotExistentFile()
+                $this->getGitFileReaderWithNotExistentFile(),
+                $this->getGit(),
             ))->create()
         );
+        self::assertEquals('main', $resolved->getMainBranch());
 
-        $this->assertNoOutput();
+        $this->assertOutputMatches([
+            'No "main_branch" was not set, this value will default to "main" in HuPKit v2.0.',
+            'The "main_branch" is resolved as "main", set the "main_branch" option in your local configuration to change this.',
+        ]);
+    }
+
+    /** @test */
+    public function it_creates_for_v2_schema_with_master_as_main_branch(): void
+    {
+        $config = new Config([
+            'schema_version' => 2,
+            'github' => [
+                'github.com' => [
+                    'username' => 'test',
+                    'api_token' => 'test-token',
+                ],
+            ],
+            'repositories' => [
+                'github.com' => [
+                    'repos' => [
+                        'park-manager/park-manager' => [
+                            'branches' => [
+                                ':default' => [
+                                    'sync-tags' => true,
+                                    'split' => [
+                                        'src/Bundle/CoreBundle' => ['url' => 'git@github.com:park-manager/core-bundle.git', 'sync-tags' => null],
+                                        'src/Bundle/UserBundle' => ['url' => 'git@github.com:park-manager/user-bundle.git', 'sync-tags' => null],
+                                        'doc' => [
+                                            'url' => 'git@github.com:park-manager/doc.git',
+                                            'sync-tags' => false,
+                                        ],
+                                    ],
+                                    'upmerge' => true,
+                                    'ignore-default' => false,
+                                    'maintained' => true,
+                                ],
+
+                                // Additional branch names for testing
+                                'main' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+                                'master' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+
+                                '0.1' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+                                '1.0' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+                                '2.0' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+
+                                // Pattern
+                                '3.x' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+                                '4.*' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+
+                                // Regexp (without anchors and options)
+                                '/[1-5]\.[0-9]/' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/brown.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+
+                                '10.0' => [
+                                    'sync-tags' => false,
+                                    'split' => [],
+                                    'upmerge' => false,
+                                    'ignore-default' => true,
+                                    'maintained' => false,
+                                ],
+
+                                // Literal branch name, no pattern
+                                '#11.x' => [
+                                    'sync-tags' => false,
+                                    'split' => [
+                                        'doc' => [
+                                            'url' => 'git@github.com:park-manager/doc2.git',
+                                            'sync-tags' => false,
+                                        ],
+                                    ],
+                                    'upmerge' => false,
+                                    'ignore-default' => true,
+                                    'maintained' => true,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'current_dir' => __DIR__ . '/Fixtures/config/schema_v2_global',
+            '_main_branch' => 'master',
+        ]);
+
+        self::assertEquals(
+            $config,
+            $resolved = (new ConfigFactory(
+                __DIR__ . '/Fixtures/config/schema_v2_global',
+                __DIR__ . '/Fixtures/config/schema_v2_global/config2.php',
+                $this->createStyle(),
+                $this->getGitFileReaderWithNotExistentFile(),
+                $this->getGit('master'),
+            ))->create()
+        );
+        self::assertEquals('master', $resolved->getMainBranch());
+
+        $this->assertOutputMatches([
+            'No "main_branch" was not set, this value will default to "main" in HuPKit v2.0.',
+            'The "main_branch" is resolved as "master", set the "main_branch" option in your local configuration to change this.',
+        ]);
+    }
+
+    /** @test */
+    public function it_creates_for_v2_schema_with_a_versioned_branch_as_main_branch(): void
+    {
+        $config = new Config([
+            'schema_version' => 2,
+            'github' => [
+                'github.com' => [
+                    'username' => 'test',
+                    'api_token' => 'test-token',
+                ],
+            ],
+            'repositories' => [
+                'github.com' => [
+                    'repos' => [
+                        'park-manager/park-manager' => [
+                            'branches' => [
+                                ':default' => [
+                                    'sync-tags' => true,
+                                    'split' => [
+                                        'src/Bundle/CoreBundle' => ['url' => 'git@github.com:park-manager/core-bundle.git', 'sync-tags' => null],
+                                        'src/Bundle/UserBundle' => ['url' => 'git@github.com:park-manager/user-bundle.git', 'sync-tags' => null],
+                                        'doc' => [
+                                            'url' => 'git@github.com:park-manager/doc.git',
+                                            'sync-tags' => false,
+                                        ],
+                                    ],
+                                    'upmerge' => true,
+                                    'ignore-default' => false,
+                                    'maintained' => true,
+                                ],
+
+                                // Additional branch names for testing
+                                'main' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+                                'master' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+
+                                '0.1' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+                                '1.0' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+                                '2.0' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+
+                                // Pattern
+                                '3.x' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+                                '4.*' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+
+                                // Regexp (without anchors and options)
+                                '/[1-5]\.[0-9]/' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/brown.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+
+                                '10.0' => [
+                                    'sync-tags' => false,
+                                    'split' => [],
+                                    'upmerge' => false,
+                                    'ignore-default' => true,
+                                    'maintained' => false,
+                                ],
+
+                                // Literal branch name, no pattern
+                                '#11.x' => [
+                                    'sync-tags' => false,
+                                    'split' => [
+                                        'doc' => [
+                                            'url' => 'git@github.com:park-manager/doc2.git',
+                                            'sync-tags' => false,
+                                        ],
+                                    ],
+                                    'upmerge' => false,
+                                    'ignore-default' => true,
+                                    'maintained' => true,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'current_dir' => __DIR__ . '/Fixtures/config/schema_v2_global',
+            '_main_branch' => '3.0',
+        ]);
+
+        self::assertEquals(
+            $config,
+            $resolved = (new ConfigFactory(
+                __DIR__ . '/Fixtures/config/schema_v2_global',
+                __DIR__ . '/Fixtures/config/schema_v2_global/config2.php',
+                $this->createStyle(),
+                $this->getGitFileReaderWithNotExistentFile(),
+                $this->getGit(null, ['1.0', '2.0', '3.0']),
+            ))->create()
+        );
+        self::assertEquals('3.0', $resolved->getMainBranch());
+
+        $this->assertOutputMatches([
+            'No "main_branch" was not set, this value will default to "main" in HuPKit v2.0.',
+            'The "main_branch" is resolved as "3.0", set the "main_branch" option in your local configuration to change this.',
+        ]);
+    }
+
+    /** @test */
+    public function it_creates_for_v2_schema_without_any_known_branch_as_main_branch(): void
+    {
+        $config = new Config([
+            'schema_version' => 2,
+            'github' => [
+                'github.com' => [
+                    'username' => 'test',
+                    'api_token' => 'test-token',
+                ],
+            ],
+            'repositories' => [
+                'github.com' => [
+                    'repos' => [
+                        'park-manager/park-manager' => [
+                            'branches' => [
+                                ':default' => [
+                                    'sync-tags' => true,
+                                    'split' => [
+                                        'src/Bundle/CoreBundle' => ['url' => 'git@github.com:park-manager/core-bundle.git', 'sync-tags' => null],
+                                        'src/Bundle/UserBundle' => ['url' => 'git@github.com:park-manager/user-bundle.git', 'sync-tags' => null],
+                                        'doc' => [
+                                            'url' => 'git@github.com:park-manager/doc.git',
+                                            'sync-tags' => false,
+                                        ],
+                                    ],
+                                    'upmerge' => true,
+                                    'ignore-default' => false,
+                                    'maintained' => true,
+                                ],
+
+                                // Additional branch names for testing
+                                'main' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+                                'master' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+
+                                '0.1' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+                                '1.0' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+                                '2.0' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+
+                                // Pattern
+                                '3.x' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+                                '4.*' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+
+                                // Regexp (without anchors and options)
+                                '/[1-5]\.[0-9]/' => ['split' => ['doc' => ['url' => 'git@github.com:park-manager/brown.git', 'sync-tags' => null]], 'upmerge' => true, 'sync-tags' => true, 'ignore-default' => false, 'maintained' => true],
+
+                                '10.0' => [
+                                    'sync-tags' => false,
+                                    'split' => [],
+                                    'upmerge' => false,
+                                    'ignore-default' => true,
+                                    'maintained' => false,
+                                ],
+
+                                // Literal branch name, no pattern
+                                '#11.x' => [
+                                    'sync-tags' => false,
+                                    'split' => [
+                                        'doc' => [
+                                            'url' => 'git@github.com:park-manager/doc2.git',
+                                            'sync-tags' => false,
+                                        ],
+                                    ],
+                                    'upmerge' => false,
+                                    'ignore-default' => true,
+                                    'maintained' => true,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'current_dir' => __DIR__ . '/Fixtures/config/schema_v2_global',
+            '_main_branch' => 'main',
+        ]);
+
+        self::assertEquals(
+            $config,
+            $resolved = (new ConfigFactory(
+                __DIR__ . '/Fixtures/config/schema_v2_global',
+                __DIR__ . '/Fixtures/config/schema_v2_global/config2.php',
+                $this->createStyle(),
+                $this->getGitFileReaderWithNotExistentFile(),
+                $this->getGitWithActiveExpected(),
+            ))->create()
+        );
+        self::assertEquals('main', $resolved->getMainBranch());
+
+        $this->assertOutputMatches([
+            'No "main_branch" was not set, this value will default to "main" in HuPKit v2.0.',
+            'The "main_branch" is resolved as "main", set the "main_branch" option in your local configuration to change this.',
+        ]);
     }
 
     /** @test */
@@ -262,6 +557,8 @@ final class ConfigFactoryTest extends TestCase
                 ],
             ],
             '_local' => [
+                'schema_version' => 2,
+                'main_branch' => 'trunk',
                 'branches' => [
                     ':default' => [
                         'upmerge' => true,
@@ -300,13 +597,15 @@ final class ConfigFactoryTest extends TestCase
 
         self::assertEquals(
             $config,
-            (new ConfigFactory(
+            $resolved = (new ConfigFactory(
                 __DIR__ . '/Fixtures/config/schema_v2_local',
                 __DIR__ . '/Fixtures/config/schema_v2_global/config.php',
                 $this->createStyle(),
-                $this->getGitFileReaderWithExistentFile(__DIR__ . '/Fixtures/config/schema_v2_local/.hubkit/config.php')
+                $this->getGitFileReaderWithExistentFile(__DIR__ . '/Fixtures/config/schema_v2_local/.hubkit/config.php'),
+                $this->getGit(),
             ))->create()
         );
+        self::assertEquals('trunk', $resolved->getMainBranch());
 
         $this->assertNoOutput();
     }
@@ -328,18 +627,19 @@ final class ConfigFactoryTest extends TestCase
     public function it_validates_configuration(string $configFile, string $message): void
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Configuration contains one or more errors: ' . $message);
+        $this->expectExceptionMessage('Configuration contains one or more errors. ' . $message);
 
         (new ConfigFactory(
             __DIR__ . '/Fixtures/config/schema_v2_global',
             __DIR__ . '/Fixtures/config/invalid/' . $configFile,
             $this->createStyle(),
-            $this->getGitFileReaderWithNotExistentFile()
+            $this->getGitFileReaderWithNotExistentFile(),
+            $this->getGit(),
         ))->create();
     }
 
     /** @return iterable<string, array{0: string, 1: string}> */
-    public function provideInvalidConfigs(): iterable
+    public static function provideInvalidConfigs(): iterable
     {
         yield 'branches: non versioned branch' => ['invalid_branch_name.php', 'Invalid configuration for path "hubkit.repositories.github.com.repos.park-manager/park-manager.branches": Invalid version or relative pattern "nee", must be either "1.x" or "1.*", or "#1.x" (for an exact branch named 1.x), ":default", "main" or "master", or a regexp like "/0.[1-9]+/".'];
         yield 'branches: v prefix' => ['invalid_branch_pattern.php', 'Invalid configuration for path "hubkit.repositories.github.com.repos.park-manager/park-manager.branches": Invalid version or relative pattern "v2.0", must be either "1.x" or "1.*", or "#1.x" (for an exact branch named 1.x), ":default", "main" or "master", or a regexp like "/0.[1-9]+/".'];
@@ -347,5 +647,106 @@ final class ConfigFactoryTest extends TestCase
         yield 'branches: invalid regexp' => ['invalid_branch_regexp.php', 'Invalid configuration for path "hubkit.repositories.github.com.repos.park-manager/park-manager.branches": Invalid regexp "\/[]\/" error: "preg_match(): Compilation failed: missing terminating ] for character class at offset 2".'];
         yield 'branches: regexp with options' => ['invalid_branch_regexp2.php', 'Invalid configuration for path "hubkit.repositories.github.com.repos.park-manager/park-manager.branches": Invalid regexp "\/\\\\d\\\\.\\\\d+\/s", cannot contain start/end anchor or options. Either "/[5-9]\.x/" not "/^[5-9].x$/i".'];
         yield 'branches: regexp with anchors' => ['invalid_branch_regexp3.php', 'Invalid configuration for path "hubkit.repositories.github.com.repos.park-manager/park-manager.branches": Invalid regexp "\/^\\\\d\\\\.\\\\d+$\/", cannot contain start/end anchor or options. Either "/[5-9]\.x/" not "/^[5-9].x$/i".'];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideInvalidMainBranches
+     */
+    public function it_requires_main_branch_is_valid(string $branch, string $message): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Local configuration contains one or more errors. Invalid configuration for path "hubkit.main_branch": ' . $message);
+
+        $factory = new ConfigFactory(
+            __DIR__ . '/Fixtures/config/schema_v2_global',
+            __DIR__ . '/Fixtures/config/schema_v2_global/config2.php',
+            $this->createStyle(),
+            $this->getGitFileReaderWithNotExistentFile(),
+            $this->getGit(),
+        );
+
+        $factory->resolveLocalConfig(['schema_version' => 2, 'main_branch' => $branch]);
+    }
+
+    /** @return iterable<string, array{0: string, 1: string}> */
+    public static function provideInvalidMainBranches(): iterable
+    {
+        yield 'head ref' => ['head', 'Cannot use Git ref HEAD as branch name.'];
+        yield 'HEAD ref' => ['HEAD', 'Cannot use Git ref HEAD as branch name.'];
+        yield 'heads ref' => ['heads/main', 'Cannot start with Git refs (heads, tags, remotes, notes)/.'];
+        yield 'tags ref' => ['tags/v1.0.0', 'Cannot start with Git refs (heads, tags, remotes, notes)/.'];
+        yield 'remote ref' => ['remotes/upstream/main', 'Cannot start with Git refs (heads, tags, remotes, notes)/.'];
+        yield 'notes ref' => ['notes/pull-request-metadata', 'Cannot start with Git refs (heads, tags, remotes, notes)/.'];
+
+        yield 'double dot' => ['feature../main', 'Invalid name provided, must follow the Git convention for branch names.'];
+        yield 'double slash' => ['feature//main', 'Invalid name provided, must follow the Git convention for branch names.'];
+        yield 'begins with slash' => ['/feature/main', 'Invalid name provided, must follow the Git convention for branch names.'];
+        yield 'ends with slash' => ['feature/main/', 'Invalid name provided, must follow the Git convention for branch names.'];
+        yield 'space character' => ['feature main', 'Invalid name provided, must follow the Git convention for branch names.'];
+        yield 'double-dash' => ['feature--main', 'Invalid name provided, must follow the Git convention for branch names.'];
+        yield 'double-dash with slash' => ['feature/-main', 'Invalid name provided, must follow the Git convention for branch names.'];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideValidMainBranches
+     */
+    public function it_accepts_valid_main_branch_value(string $branch): void
+    {
+        $factory = new ConfigFactory(
+            __DIR__ . '/Fixtures/config/schema_v2_global',
+            __DIR__ . '/Fixtures/config/schema_v2_global/config2.php',
+            $this->createStyle(),
+            $this->getGitFileReaderWithNotExistentFile(),
+            $this->getGit(),
+        );
+
+        $config = $factory->resolveLocalConfig(['schema_version' => 2, 'main_branch' => $branch]);
+
+        self::assertEquals($branch, $config['main_branch']);
+    }
+
+    /** @return iterable<string, array{0: string}> */
+    public static function provideValidMainBranches(): iterable
+    {
+        yield 'main' => ['main'];
+        yield 'HEAD-ish' => ['HEADing'];
+        yield 'dash' => ['main-master'];
+        yield 'underscore' => ['main_master'];
+        yield 'versioned' => ['2.0'];
+        yield 'relative' => ['2.x'];
+        yield 'nested' => ['development/new'];
+        yield 'nested deep' => ['development/remotes/new'];
+        yield 'unicode' => ["\xCE\xA9"];
+    }
+
+    /** @param array<int, string>|null $versionedBranches */
+    private function getGit(?string $expectedBranch = 'main', ?array $versionedBranches = []): Git
+    {
+        $gitProphecy = $this->prophesize(Git::class);
+        $gitProphecy->branchExists(Argument::any())->willReturn(false);
+
+        if ($expectedBranch) {
+            $gitProphecy->branchExists($expectedBranch)->willReturn(true);
+        }
+
+        if ($versionedBranches) {
+            $gitProphecy->getVersionBranches()->willReturn($versionedBranches);
+        }
+
+        return $gitProphecy->reveal();
+    }
+
+    private function getGitWithActiveExpected(string $branch = 'main'): Git
+    {
+        $gitProphecy = $this->prophesize(Git::class);
+        $gitProphecy->branchExists(Argument::any())->willReturn(false);
+        $gitProphecy->getVersionBranches()->willReturn([]);
+        $gitProphecy->getActiveBranchName()->willReturn($branch);
+
+        return $gitProphecy->reveal();
     }
 }

--- a/tests/Fixtures/config/schema_v2_local/.hubkit/config.php
+++ b/tests/Fixtures/config/schema_v2_local/.hubkit/config.php
@@ -1,6 +1,9 @@
 <?php
 
 return [
+    'schema_version' => 2,
+    'main_branch' => 'trunk',
+
     'branches' => [
         ':default' => [],
         '2.0' => [

--- a/tests/Functional/GitTesterTrait.php
+++ b/tests/Functional/GitTesterTrait.php
@@ -116,6 +116,14 @@ trait GitTesterTrait
         }
     }
 
+    /** @param iterable<string> $branches */
+    protected function givenBranchesExist(iterable $branches): void
+    {
+        foreach ($branches as $branch) {
+            $this->runCliCommand(['git', 'branch', $branch]);
+        }
+    }
+
     protected function setUpstreamRepository(): void
     {
         $upstreamRepos = $this->createBareGitDirectory($this->getTempDir() . '/git3');

--- a/tests/Functional/Service/Git/GitBranchTest.php
+++ b/tests/Functional/Service/Git/GitBranchTest.php
@@ -124,10 +124,18 @@ final class GitBranchTest extends TestCase
     public function it_gets_versioned_branches_in_correct_order(): void
     {
         $this->addRemote('upstream', $this->remoteRepository);
-        $this->givenRemoteBranchesExist(['1.0', 'v1.1', '2.0', 'x.1']);
+        $this->givenRemoteBranchesExist(['1.0', 'v1.1', '2.0', '1.x', 'x.1']);
 
-        self::assertSame(['1.0', 'v1.1', '2.0'], $this->git->getVersionBranches('origin'));
+        self::assertSame(['1.0', 'v1.1', '1.x', '2.0'], $this->git->getVersionBranches('origin'));
         self::assertSame([], $this->git->getVersionBranches('upstream'));
+    }
+
+    /** @test */
+    public function it_gets_local_versioned_branches_in_correct_order(): void
+    {
+        $this->givenBranchesExist(['1.0', 'v1.1', '2.0', '1.x', 'x.1']);
+
+        self::assertSame(['1.0', 'v1.1', '1.x', '2.0'], $this->git->getVersionBranches());
     }
 
     /** @test */

--- a/tests/Handler/UpMergeHandlerTest.php
+++ b/tests/Handler/UpMergeHandlerTest.php
@@ -69,6 +69,7 @@ final class UpMergeHandlerTest extends TestCase
                     ],
                 ],
             ],
+            '_main_branch' => 'master',
         ]);
         $this->config->setActiveRepository('github.com', 'park-manager/hubkit');
 
@@ -347,7 +348,17 @@ final class UpMergeHandlerTest extends TestCase
     /** @test */
     public function it_does_nothing_when_current_is_last_branch(): void
     {
-        $this->github->getDefaultBranch()->willReturn('2.3');
+        $this->config = new Config([
+            'repositories' => [
+                'github.com' => [
+                    'repos' => [
+                        'park-manager/park-manager' => [],
+                    ],
+                ],
+            ],
+            '_main_branch' => '2.3',
+        ]);
+        $this->config->setActiveRepository('github.com', 'park-manager/hubkit');
 
         $this->git->getActiveBranchName()->willReturn('2.6');
         $this->git->remoteUpdate('upstream')->shouldBeCalled();
@@ -476,7 +487,17 @@ final class UpMergeHandlerTest extends TestCase
     /** @test */
     public function it_merges_current_branch_into_next_version_branches_without_master_branch(): void
     {
-        $this->github->getDefaultBranch()->willReturn('2.x');
+        $this->config = new Config([
+            'repositories' => [
+                'github.com' => [
+                    'repos' => [
+                        'park-manager/park-manager' => [],
+                    ],
+                ],
+            ],
+            '_main_branch' => '2.x',
+        ]);
+        $this->config->setActiveRepository('github.com', 'park-manager/hubkit');
 
         $this->git->getActiveBranchName()->willReturn('2.3');
         $this->git->remoteUpdate('upstream')->shouldBeCalled();
@@ -598,6 +619,7 @@ final class UpMergeHandlerTest extends TestCase
                     ],
                 ],
             ],
+            '_main_branch' => 'master',
         ]);
         $this->config->setActiveRepository('github.com', 'park-manager/hubkit');
     }
@@ -665,6 +687,7 @@ final class UpMergeHandlerTest extends TestCase
                     ],
                 ],
             ],
+            '_main_branch' => 'master',
         ]);
         $this->config->setActiveRepository('github.com', 'park-manager/hubkit');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT

By convention one branch must be the primary (or main) branch to which all work is eventually merged to.
For upmerge this is the last branch in the last, previously this was automatically detected. But since some projects use master and others main, and some even a (relative) versioned name, it's best to allow making this explicit.

For now it guesses by in order main, master, and finally the last versioned branch.
If this fails the current branch is used, and _when_ that ones fails, main is used.

In HuPKit v2.0 this value will default to main.

Todo: Update documentation.

```
$ hk upmerge --dry-run

 ! No "main_branch" was not set, this value will default to "main" in HuPKit v2.0.
 ! The "main_branch" is resolved as "main", set the "main_branch" option in your local configuration to change this.
```
