### PR TITLE
Allow to choose remote-name for upstream

### DIFF
--- a/bin/hubkit.php
+++ b/bin/hubkit.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 use HubKit\Cli\HubKitApplicationConfig;
 use HubKit\Container;
+use HubKit\RemotesConfigParser;
 use Symfony\Component\ErrorHandler\DebugClassLoader;
 use Symfony\Component\ErrorHandler\ErrorHandler;
 use Webmozart\Console\ConsoleApplication;
@@ -28,6 +29,15 @@ if (! file_exists(__DIR__ . '/../config.php') && file_exists(__DIR__ . '/../conf
 
     exit(1);
 }
+
+if (file_exists(getcwd() . '/.hk_remotes')) {
+    $remotesNames = RemotesConfigParser::parse((string) file_get_contents(getcwd() . '/.hk_remotes'));
+} else {
+    $remotesNames = [];
+}
+
+define('REMOTE_MAIN', $remotesNames['main'] ?? 'upstream');
+define('REMOTE_FORK', $remotesNames['fork'] ?? 'origin');
 
 $parameters = [];
 $parameters['current_dir'] = getcwd() . '/';

--- a/docs/config.md
+++ b/docs/config.md
@@ -267,6 +267,36 @@ either a 'push url' or an array with following options
 **Note:** Missing directories are ignored with a warning. In HuPKit v2.0 this behavior is bound to change,
 use the branches configuration to ensure to paths are missing.
 
+Remote names
+------------
+
+By default HuPKit uses "upstream" as the remote-name for the main-repository.
+If for any reason you need to change this, either because you use a different
+convention or only use "origin" without a fork, you can use a local configuration
+file to change this.
+
+Add a ".hk_remotes" file at the root-level of your repository with the following contents:
+
+```ini
+; Commented line
+
+main = upstream
+fork = origin
+```
+
+The config "main" is the main repository which all team-members pull and push from,
+"fork" is your own fork (if any).
+
+**Note:** This is about remote _names_ not actual repository url's.
+
+A line can contain either a comment _or_ a variable, no overwrites, no different names
+and not comments at the end of a declaration.
+
+**Caution:** This file should be ignored by Git as it only applies to your own local 
+`.git/config` file. 
+
+Use the `-v` flag with any command to see which value is used.
+
 ### Whats next?
 
 Run the `self-diagnose` command to ensure everything is configured correctly.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,10 @@
 
         <env name="COLUMNS" value="272" />
         <env name="LINES" value="52" />
+
+        <!-- Use the test_ prefix to ensure no references are missed -->
+        <const name="REMOTE_MAIN" value="test_upstream" />
+        <const name="REMOTE_FORK" value="test_origin" />
     </php>
 
     <coverage>

--- a/src/Cli/Handler/ConfigBaseHandler.php
+++ b/src/Cli/Handler/ConfigBaseHandler.php
@@ -35,7 +35,7 @@ abstract class ConfigBaseHandler extends GitBaseHandler
 
     protected function ensureRemoteIsNotDiverged(): void
     {
-        $diffStatus = $this->git->getRemoteDiffStatus('upstream', '_hubkit');
+        $diffStatus = $this->git->getRemoteDiffStatus(REMOTE_MAIN, '_hubkit');
 
         if ($diffStatus !== Git::STATUS_UP_TO_DATE) {
             throw new \RuntimeException(

--- a/src/Cli/Handler/EditConfigHandler.php
+++ b/src/Cli/Handler/EditConfigHandler.php
@@ -36,7 +36,7 @@ class EditConfigHandler extends ConfigBaseHandler
         }
 
         if (! $this->git->branchExists('_hubkit')) {
-            if ($this->git->remoteBranchExists('upstream', '_hubkit')) {
+            if ($this->git->remoteBranchExists(REMOTE_MAIN, '_hubkit')) {
                 throw new \RuntimeException(
                     'The "_hubkit" branch exists remote, but the branch was not found locally.' . \PHP_EOL .
                     'Run the "sync-config" command to pull-in the remote branch.' . \PHP_EOL
@@ -60,7 +60,7 @@ class EditConfigHandler extends ConfigBaseHandler
             'The "_hubkit" configuration branch was checked out.',
             'Make sure to add and commit once you are done.',
             sprintf('After you are done run `git checkout %s`.', $activeBranch),
-            'And run the `sync-config` command to push the configuration to the upstream repository.',
+            'And run the `sync-config` command to push the configuration to the remote repository.',
         ]);
     }
 

--- a/src/Cli/Handler/InitConfigHandler.php
+++ b/src/Cli/Handler/InitConfigHandler.php
@@ -53,7 +53,7 @@ final class InitConfigHandler extends ConfigBaseHandler
             throw new \RuntimeException('The "_hubkit" branch already exists. Run `edit-config` instead.');
         }
 
-        if ($this->git->remoteBranchExists('upstream', '_hubkit')) {
+        if ($this->git->remoteBranchExists(REMOTE_MAIN, '_hubkit')) {
             throw new \RuntimeException(
                 'The "_hubkit" branch exists remote, but the branch was not found locally.' . \PHP_EOL .
                 'Run the "sync-config" command to pull-in the remote branch.' . \PHP_EOL
@@ -69,7 +69,7 @@ final class InitConfigHandler extends ConfigBaseHandler
             'The "_hubkit" configuration branch was created, edit the config.php file with your favorite editor.',
             'Make sure to add to and commit once you are done.',
             sprintf('After you are done run `git checkout %s`.', $activeBranch),
-            'And finally run the `sync-config` command to push the configuration to the upstream repository.',
+            'And finally run the `sync-config` command to push the configuration to the remote repository.',
         ]);
 
         return 0;

--- a/src/Cli/Handler/MergeHandler.php
+++ b/src/Cli/Handler/MergeHandler.php
@@ -367,16 +367,16 @@ final class MergeHandler extends GitBaseHandler
             );
         }
 
-        $this->git->ensureNotesFetching('upstream');
+        $this->git->ensureNotesFetching(REMOTE_MAIN);
 
         // Pull-request was merged remote, so to make adding notes possible
         // we need the actual reference local. Don't use pull as the working dir
         // could be stale.
-        $this->git->remoteUpdate('upstream');
+        $this->git->remoteUpdate(REMOTE_MAIN);
         $this->git->addNotes($commentText, $sha, 'github-comments');
 
         if ($commentText !== '') {
-            $this->git->pushToRemote('upstream', 'refs/notes/github-comments');
+            $this->git->pushToRemote(REMOTE_MAIN, 'refs/notes/github-comments');
         }
     }
 
@@ -393,7 +393,7 @@ final class MergeHandler extends GitBaseHandler
         }
 
         $this->git->checkout($branch);
-        $this->git->pullRemote('upstream', $branch);
+        $this->git->pullRemote(REMOTE_MAIN, $branch);
 
         $this->style->success(sprintf('Your local "%s" branch is updated.', $branch));
 

--- a/src/Cli/Handler/ReleaseHandler.php
+++ b/src/Cli/Handler/ReleaseHandler.php
@@ -58,7 +58,7 @@ final class ReleaseHandler extends GitBaseHandler
         $versionStr = (string) $version;
 
         $this->validateBranchCompatibility($branch, $version);
-        $this->git->ensureBranchInSync('upstream', $branch);
+        $this->git->ensureBranchInSync(REMOTE_MAIN, $branch);
 
         $this->style->writeln(
             [
@@ -88,7 +88,7 @@ final class ReleaseHandler extends GitBaseHandler
         $this->branchSplitsh->syncTags($branch, $versionStr);
 
         $this->process->mustRun(['git', 'tag', '-s', 'v' . $versionStr, '-m', 'Release ' . $versionStr]);
-        $this->process->mustRun(['git', 'push', 'upstream', 'v' . $versionStr]);
+        $this->process->mustRun(['git', 'push', REMOTE_MAIN, 'v' . $versionStr]);
 
         $release = $this->github->createRelease('v' . $versionStr, $changelog, $args->getOption('pre-release'), $args->getOption('title'));
 
@@ -107,7 +107,7 @@ final class ReleaseHandler extends GitBaseHandler
             return;
         }
 
-        if ($this->git->remoteBranchExists('upstream', $expected = $version->major . '.' . $version->minor)) {
+        if ($this->git->remoteBranchExists(REMOTE_MAIN, $expected = $version->major . '.' . $version->minor)) {
             $this->style->warning(
                 [
                     sprintf('This release will be created for the "%s" branch.', $branch),

--- a/src/Cli/Handler/SelfDiagnoseHandler.php
+++ b/src/Cli/Handler/SelfDiagnoseHandler.php
@@ -193,7 +193,7 @@ final class SelfDiagnoseHandler
 
     private function testUpstreamRemoteSet(StatusTable $table): void
     {
-        $label = 'Git remote "upstream" configured';
+        $label = sprintf('Git remote "%s" configured', REMOTE_MAIN);
 
         if (! $this->git->isGitDir()) {
             $table->addRow($label, 'skipped', 'This is not a Git repository');
@@ -201,12 +201,12 @@ final class SelfDiagnoseHandler
             return;
         }
 
-        $result = $this->git->getGitConfig('remote.upstream.url');
+        $result = $this->git->getGitConfig(sprintf('remote.%s.url', REMOTE_MAIN));
 
         if ($result !== '') {
             $table->addRow($label, 'success', $result);
         } else {
-            $table->addRow($label, 'failure', 'Git remote "upstream" should be configured');
+            $table->addRow($label, 'failure', sprintf('Git remote "%s" should be configured', REMOTE_MAIN));
         }
     }
 
@@ -220,7 +220,7 @@ final class SelfDiagnoseHandler
             return;
         }
 
-        if ($this->git->getGitConfig('remote.upstream.url') === '' || $this->github->getHostname() === '') {
+        if ($this->git->getGitConfig(sprintf('remote.%s.url', REMOTE_MAIN)) === '' || $this->github->getHostname() === '') {
             $table->addRow($label, 'skipped', 'Unable to detect host and repository');
 
             return;
@@ -233,12 +233,12 @@ final class SelfDiagnoseHandler
                 return;
             }
 
-            if ($this->gitFileReader->fileExistsAtRemote('upstream', '_hubkit', 'config.php')) {
-                $status = $this->git->getRemoteDiffStatus('upstream', '_hubkit');
+            if ($this->gitFileReader->fileExistsAtRemote(REMOTE_MAIN, '_hubkit', 'config.php')) {
+                $status = $this->git->getRemoteDiffStatus(REMOTE_MAIN, '_hubkit');
 
                 if ($status !== Git::STATUS_UP_TO_DATE) {
                     $table->addRow($label, 'warning',
-                        sprintf('Branch "_hubkit" is diverged with upstream: %s%sRun sync-config to update', $status, "\n")
+                        sprintf('Branch "_hubkit" is diverged with remote repository: %s%sRun sync-config to update', $status, "\n")
                     );
 
                     return;
@@ -250,17 +250,17 @@ final class SelfDiagnoseHandler
             return;
         }
 
-        if ($this->git->remoteBranchExists('upstream', '_hubkit')) {
-            if ($this->gitFileReader->fileExistsAtRemote('upstream', '_hubkit', 'config.php')) {
-                $table->addRow($label, 'info', 'Found config.php in branch "_hubkit" at remote "upstream", but not local');
+        if ($this->git->remoteBranchExists(REMOTE_MAIN, '_hubkit')) {
+            if ($this->gitFileReader->fileExistsAtRemote(REMOTE_MAIN, '_hubkit', 'config.php')) {
+                $table->addRow($label, 'info', 'Found config.php in branch "_hubkit" at remote repository, but not local');
             } else {
-                $table->addRow($label, 'failure', 'Branch "_hubkit" at upstream exists but config.php was not found');
+                $table->addRow($label, 'failure', 'Branch "_hubkit" at remote repository exists but config.php was not found');
             }
 
             return;
         }
 
-        $table->addRow($label, 'skipped', 'Branch _hubkit" was neither found locally or at remote "upstream"');
+        $table->addRow($label, 'skipped', 'Branch _hubkit" was neither found locally or at remote repository');
     }
 
     private function getGitVersion(): string

--- a/src/Cli/Handler/SplitCreatedHandler.php
+++ b/src/Cli/Handler/SplitCreatedHandler.php
@@ -24,7 +24,7 @@ class SplitCreatedHandler extends GitBaseHandler
     public function handle(Args $args): void
     {
         $this->git->guardWorkingTreeReady();
-        $this->git->remoteUpdate('upstream');
+        $this->git->remoteUpdate(REMOTE_MAIN);
 
         $this->style->title('Repository Split Create');
         $this->informationHeader();

--- a/src/Cli/Handler/SplitRepoHandler.php
+++ b/src/Cli/Handler/SplitRepoHandler.php
@@ -35,7 +35,7 @@ final class SplitRepoHandler extends GitBaseHandler
     public function handle(Args $args): void
     {
         $this->git->guardWorkingTreeReady();
-        $this->git->remoteUpdate('upstream');
+        $this->git->remoteUpdate(REMOTE_MAIN);
 
         $branch = $this->getBranchName($args);
         $prefix = $args->getOption('prefix');
@@ -72,7 +72,7 @@ final class SplitRepoHandler extends GitBaseHandler
             return $this->git->getActiveBranchName();
         }
 
-        $this->git->checkoutRemoteBranch('upstream', $branch);
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, $branch);
 
         return $branch;
     }

--- a/src/Cli/Handler/SwitchBaseHandler.php
+++ b/src/Cli/Handler/SwitchBaseHandler.php
@@ -55,14 +55,14 @@ final class SwitchBaseHandler extends GitBaseHandler
 
         $this->git->ensureRemoteExists($remote, $pullRequest['head']['repo']['ssh_url']);
         $this->git->remoteUpdate($remote);
-        $this->git->remoteUpdate('upstream');
+        $this->git->remoteUpdate(REMOTE_MAIN);
 
         // Operation was already in progress (but gave a conflict).
         if ($this->filesystem->fileExists($this->git->getGitDirectory() . '/.hubkit-switch')) {
             $this->handleIncompleteOperation($remote, $tmpBranch, $branch);
         }
 
-        $this->switchBranchBase($remote, $branch, 'upstream/' . $pullRequest['base']['ref'], $newBase, $tmpBranch);
+        $this->switchBranchBase($remote, $branch, REMOTE_MAIN . '/' . $pullRequest['base']['ref'], $newBase, $tmpBranch);
         $this->pushToRemote($remote, $tmpBranch, $branch);
         $this->deleteTempBranch($tmpBranch);
 
@@ -141,7 +141,7 @@ final class SwitchBaseHandler extends GitBaseHandler
         $this->filesystem->dumpFile($this->git->getGitDirectory() . '/.hubkit-switch', $tmpBranch);
 
         try {
-            $this->process->mustRun(['git', 'rebase', '--onto', 'upstream/' . $newBase, $currentBase, $tmpBranch]);
+            $this->process->mustRun(['git', 'rebase', '--onto', REMOTE_MAIN . '/' . $newBase, $currentBase, $tmpBranch]);
             $this->git->checkout($activeBranch);
         } catch (ProcessFailedException $e) {
             throw new \RuntimeException(
@@ -201,7 +201,7 @@ final class SwitchBaseHandler extends GitBaseHandler
             throw new \InvalidArgumentException(sprintf('Cannot switch base, current base is already "%s".', $newBase));
         }
 
-        if (! $this->git->remoteBranchExists('upstream', $newBase)) {
+        if (! $this->git->remoteBranchExists(REMOTE_MAIN, $newBase)) {
             throw new \InvalidArgumentException(sprintf('Cannot switch base, base branch "%s" does not exists.', $newBase));
         }
     }

--- a/src/Cli/Handler/SynchronizeConfigHandler.php
+++ b/src/Cli/Handler/SynchronizeConfigHandler.php
@@ -26,37 +26,37 @@ final class SynchronizeConfigHandler extends GitBaseHandler
 
         $this->style->title('Configuration Synchronizer');
 
-        if (! $this->git->remoteBranchExists('upstream', '_hubkit')) {
+        if (! $this->git->remoteBranchExists(REMOTE_MAIN, '_hubkit')) {
             if (! $this->git->branchExists('_hubkit')) {
                 $this->style->success('HuPKit configuration is not set-up yet, run `init-config` first.');
 
                 return 1;
             }
 
-            $this->git->pushToRemote('upstream', '_hubkit:_hubkit');
+            $this->git->pushToRemote(REMOTE_MAIN, '_hubkit:_hubkit');
 
             $this->style->success('Successfully pushed the _hubkit branch.');
 
             return 0;
         }
 
-        switch ($this->git->getRemoteDiffStatus('upstream', '_hubkit')) {
+        switch ($this->git->getRemoteDiffStatus(REMOTE_MAIN, '_hubkit')) {
             case Git::STATUS_UP_TO_DATE:
-                $this->style->info('Already up-to-date.');
+                $this->style->info('Already up-to-date with remote repository.');
 
                 return 0;
 
             case Git::STATUS_NEED_PULL:
                 $this->style->note('Pulling changes.');
-                $this->git->fetchRemote('upstream', '_hubkit:_hubkit');
-                $this->style->success('Updated your local _hubkit branch.');
+                $this->git->fetchRemote(REMOTE_MAIN, '_hubkit:_hubkit');
+                $this->style->success('Updated your local _hubkit branch with repository repository.');
 
                 return 0;
 
             case Git::STATUS_NEED_PUSH:
-                $this->style->text('Local version is ahead with remote upstream.');
-                $this->git->pushToRemote('upstream', '_hubkit:_hubkit');
-                $this->style->success('Pushed changes to upstream.');
+                $this->style->text('Local version is ahead with remote.');
+                $this->git->pushToRemote(REMOTE_MAIN, '_hubkit:_hubkit');
+                $this->style->success('Pushed changes to remote repository.');
 
                 return 0;
         }

--- a/src/Cli/Handler/TakeHandler.php
+++ b/src/Cli/Handler/TakeHandler.php
@@ -46,8 +46,8 @@ final class TakeHandler extends GitBaseHandler
             return;
         }
 
-        $this->git->remoteUpdate('upstream');
-        $this->git->checkoutRemoteBranch('upstream', $base);
+        $this->git->remoteUpdate(REMOTE_MAIN);
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, $base);
         $this->git->checkout($slugTitle, true);
 
         $this->style->success(sprintf('Issue %s taken with base "%s"!', $issue['html_url'], $base));

--- a/src/Cli/Handler/UpMergeHandler.php
+++ b/src/Cli/Handler/UpMergeHandler.php
@@ -36,7 +36,7 @@ final class UpMergeHandler extends GitBaseHandler
     public function handle(Args $args): int
     {
         $this->git->guardWorkingTreeReady();
-        $this->git->remoteUpdate('upstream');
+        $this->git->remoteUpdate(REMOTE_MAIN);
 
         $branch = $this->getBranchName($args);
 
@@ -45,7 +45,7 @@ final class UpMergeHandler extends GitBaseHandler
 
         $this->guardMaintained($branch);
 
-        $branches = $this->git->getVersionBranches('upstream');
+        $branches = $this->git->getVersionBranches(REMOTE_MAIN);
 
         if (! \in_array($branch, $branches, true)) {
             $this->style->error(sprintf('Branch "%s" is not a supported version branch.', $branch));
@@ -84,7 +84,7 @@ final class UpMergeHandler extends GitBaseHandler
             return $this->git->getActiveBranchName();
         }
 
-        $this->git->checkoutRemoteBranch('upstream', $branch);
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, $branch);
 
         return $branch;
     }
@@ -126,9 +126,9 @@ final class UpMergeHandler extends GitBaseHandler
         $noSplit = $args->getOption('no-split');
 
         try {
-            $this->git->ensureBranchInSync('upstream', $branch);
+            $this->git->ensureBranchInSync(REMOTE_MAIN, $branch);
             $changedBranches = $this->mergeBranches($branch, $args->getOption('all') ? $branches : [reset($branches)], $noSplit);
-            $this->git->pushToRemote('upstream', $changedBranches);
+            $this->git->pushToRemote(REMOTE_MAIN, $changedBranches);
         } catch (\Exception $e) {
             $this->style->error(
                 [
@@ -158,8 +158,8 @@ final class UpMergeHandler extends GitBaseHandler
         $sourceBranch = $branch;
 
         foreach ($branches as $destBranch) {
-            $this->git->checkoutRemoteBranch('upstream', $destBranch);
-            $this->git->ensureBranchInSync('upstream', $destBranch);
+            $this->git->checkoutRemoteBranch(REMOTE_MAIN, $destBranch);
+            $this->git->ensureBranchInSync(REMOTE_MAIN, $destBranch);
             $this->process->mustRun(['git', 'merge', '--no-ff', '--log', $sourceBranch]);
 
             $this->style->note(sprintf('Merged "%s" into "%s"', $sourceBranch, $destBranch));
@@ -180,7 +180,7 @@ final class UpMergeHandler extends GitBaseHandler
     private function handleDryMerge(Args $args, string $branch, array $branches): int
     {
         try {
-            $this->git->ensureBranchInSync('upstream', $branch);
+            $this->git->ensureBranchInSync(REMOTE_MAIN, $branch);
             $this->dryMergeBranches($branch, $args->getOption('all') ? $branches : [reset($branches)]);
         } catch (\Exception $e) {
             $this->style->error(
@@ -205,7 +205,7 @@ final class UpMergeHandler extends GitBaseHandler
         $sourceBranch = $branch;
 
         foreach ($branches as $destBranch) {
-            $this->git->ensureBranchInSync('upstream', $destBranch);
+            $this->git->ensureBranchInSync(REMOTE_MAIN, $destBranch);
             $this->style->note(sprintf('[DRY-RUN] Merged "%s" into "%s"', $sourceBranch, $destBranch));
             $this->branchSplitsh->drySplitBranch($destBranch);
 

--- a/src/Cli/HubKitApplicationConfig.php
+++ b/src/Cli/HubKitApplicationConfig.php
@@ -116,6 +116,10 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
                     $hostname = $event->getArgs()->isOptionSet('host') ? $event->getArgs()->getOption('host') : null;
                     $this->container['github']->initializeForHost($hostname);
                 }
+
+                if ($this->container['style']->isVerbose()) {
+                    $this->container['style']->note(sprintf('Remote names set as: main=%s, fork=%s', REMOTE_MAIN, REMOTE_FORK));
+                }
             }
         );
 
@@ -245,7 +249,7 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
             ->end()
 
             ->beginCommand('sync-config')
-            ->setDescription('Synchronizes "_hubkit" configuration branch with the upstream')
+            ->setDescription('Synchronizes "_hubkit" configuration branch with the remote repository')
             ->setHandler(function () {
                 return new Handler\SynchronizeConfigHandler(
                     $this->container['style'],
@@ -282,7 +286,7 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
             ->beginCommand('switch-base')
             ->setDescription('Switch the base of a pull request (and perform a rebase to prevent unwanted commits)')
             ->addArgument('number', Argument::REQUIRED | Argument::INTEGER, 'The number of the pull request to switch')
-            ->addArgument('new-base', Argument::REQUIRED | Argument::STRING, 'New base of the pull-request (must exist in remote "upstream")')
+            ->addArgument('new-base', Argument::REQUIRED | Argument::STRING, sprintf('New base of the pull-request (must exist in remote "%s")', REMOTE_MAIN))
             ->addOption('skip-help', null, Option::NO_VALUE | Option::BOOLEAN, 'Skip the help message posted to the PR.')
             ->setHandler(function () {
                 return new Handler\SwitchBaseHandler(

--- a/src/RemotesConfigParser.php
+++ b/src/RemotesConfigParser.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HuPKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit;
+
+/**
+ * @internal
+ */
+final class RemotesConfigParser
+{
+    /**
+     * @return array{main?: string, fork?: string}
+     */
+    public static function parse(string $content): array
+    {
+        if (trim($content) === '') {
+            return [];
+        }
+
+        $lines = preg_split('{\r?\n}', $content) ?: [];
+        $vars = [];
+
+        foreach ($lines as $i => $line) {
+            if (trim($line) === '' || $line[0] === ';') {
+                continue;
+            }
+
+            if (! preg_match('/^(?P<name>[a-z+]+)\h*=\h*(?P<value>[a-z]+(?:_?[a-z]+)*?)$/', $line, $matches)) {
+                throw new \InvalidArgumentException(sprintf('Unable to process file ".hk_remotes" at line %d, expected declaration (`name=value` or `name=va_lue`), empty line or comment (`; comment`), got: %s', $i + 1, $line));
+            }
+
+            if (isset($vars[$matches['name']])) {
+                throw new \InvalidArgumentException(sprintf('Unable to process file ".hk_remotes" at line %d, declaration %s already set.', $i + 1, $matches['name']));
+            }
+
+            if ($matches['name'] !== 'main' && $matches['name'] !== 'fork') {
+                throw new \InvalidArgumentException(sprintf('Unable to process file ".hk_remotes" at line %d, declaration %s is not accepted, only "main" or "fork".', $i + 1, $matches['name']));
+            }
+
+            $vars[$matches['name']] = $matches['value'];
+        }
+
+        return $vars;
+    }
+}

--- a/src/Service/BranchSplitsh.php
+++ b/src/Service/BranchSplitsh.php
@@ -52,7 +52,7 @@ class BranchSplitsh
 
     private function getConfigForPrefix(string $branch, string $prefix): mixed
     {
-        $this->git->ensureBranchInSync('upstream', $branch);
+        $this->git->ensureBranchInSync(REMOTE_MAIN, $branch);
         $this->splitshGit->checkPrecondition();
 
         $branchConfig = $this->getBranchConfig($branch);
@@ -113,7 +113,7 @@ class BranchSplitsh
             return [];
         }
 
-        $this->git->ensureBranchInSync('upstream', $branch);
+        $this->git->ensureBranchInSync(REMOTE_MAIN, $branch);
         $this->splitshGit->checkPrecondition();
 
         $results = [];

--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -510,7 +510,7 @@ class Git
     }
 
     /** @return array{'host': string, 'org': string, 'repo': string} */
-    public function getRemoteInfo(string $name = 'upstream'): array
+    public function getRemoteInfo(string $name = REMOTE_MAIN): array
     {
         return self::getGitUrlInfo($this->getGitConfig('remote.' . $name . '.url'));
     }

--- a/src/Service/GitHub.php
+++ b/src/Service/GitHub.php
@@ -39,10 +39,10 @@ class GitHub
 
     public function autoConfigure(Git $git): void
     {
-        $repo = $git->getRemoteInfo('upstream');
+        $repo = $git->getRemoteInfo(REMOTE_MAIN);
 
         if ($repo['org'] === '') {
-            throw new \RuntimeException('Remote "upstream" is missing or is missing information, unable to configure GitHub gateway.');
+            throw new \RuntimeException(sprintf('Remote "%s" is missing or is missing information, unable to configure GitHub gateway.', REMOTE_MAIN));
         }
 
         $this->initializeForHost($repo['host']);

--- a/tests/Functional/GitTesterTrait.php
+++ b/tests/Functional/GitTesterTrait.php
@@ -127,8 +127,8 @@ trait GitTesterTrait
     protected function setUpstreamRepository(): void
     {
         $upstreamRepos = $this->createBareGitDirectory($this->getTempDir() . '/git3');
-        $this->addRemote('upstream', $upstreamRepos, $this->localRepository);
-        $this->runCliCommand(['git', 'push', 'upstream', 'master'], $this->localRepository);
+        $this->addRemote(REMOTE_MAIN, $upstreamRepos, $this->localRepository);
+        $this->runCliCommand(['git', 'push', REMOTE_MAIN, 'master'], $this->localRepository);
     }
 
     protected function givenLocalBranchesExist(iterable $branches): void

--- a/tests/Functional/Service/Git/GitBranchTest.php
+++ b/tests/Functional/Service/Git/GitBranchTest.php
@@ -123,11 +123,11 @@ final class GitBranchTest extends TestCase
     /** @test */
     public function it_gets_versioned_branches_in_correct_order(): void
     {
-        $this->addRemote('upstream', $this->remoteRepository);
+        $this->addRemote(REMOTE_MAIN, $this->remoteRepository);
         $this->givenRemoteBranchesExist(['1.0', 'v1.1', '2.0', '1.x', 'x.1']);
 
         self::assertSame(['1.0', 'v1.1', '1.x', '2.0'], $this->git->getVersionBranches('origin'));
-        self::assertSame([], $this->git->getVersionBranches('upstream'));
+        self::assertSame([], $this->git->getVersionBranches(REMOTE_MAIN));
     }
 
     /** @test */
@@ -143,16 +143,16 @@ final class GitBranchTest extends TestCase
     {
         $this->setUpstreamRepository();
         $this->givenRemoteBranchesExist(['2.0', '1.x']);
-        $this->givenRemoteBranchesExist(['3.0'], 'upstream');
+        $this->givenRemoteBranchesExist(['3.0'], REMOTE_MAIN);
 
         self::assertTrue($this->git->remoteBranchExists('origin', 'master'));
         self::assertTrue($this->git->remoteBranchExists('origin', '1.x'));
         self::assertTrue($this->git->remoteBranchExists('origin', '2.0'));
 
         self::assertFalse($this->git->remoteBranchExists('origin', '3.0'));
-        self::assertTrue($this->git->remoteBranchExists('upstream', '3.0'));
-        self::assertFalse($this->git->remoteBranchExists('upstream', '1.x'));
-        self::assertFalse($this->git->remoteBranchExists('upstream', '2.0'));
+        self::assertTrue($this->git->remoteBranchExists(REMOTE_MAIN, '3.0'));
+        self::assertFalse($this->git->remoteBranchExists(REMOTE_MAIN, '1.x'));
+        self::assertFalse($this->git->remoteBranchExists(REMOTE_MAIN, '2.0'));
     }
 
     /** @test */

--- a/tests/Functional/Service/Git/GitConfigTest.php
+++ b/tests/Functional/Service/Git/GitConfigTest.php
@@ -135,7 +135,7 @@ final class GitConfigTest extends TestCase
     /** @test */
     public function it_gets_remote_info(): void
     {
-        $this->git->ensureRemoteExists('upstream', 'https://github.com/park-manager/hubkit');
+        $this->git->ensureRemoteExists(REMOTE_MAIN, 'https://github.com/park-manager/hubkit');
 
         self::assertEquals(
             [
@@ -143,7 +143,7 @@ final class GitConfigTest extends TestCase
                 'org' => 'park-manager',
                 'repo' => 'hubkit',
             ],
-            $this->git->getRemoteInfo('upstream')
+            $this->git->getRemoteInfo(REMOTE_MAIN)
         );
     }
 

--- a/tests/Handler/EditConfigHandlerTest.php
+++ b/tests/Handler/EditConfigHandlerTest.php
@@ -42,7 +42,7 @@ final class EditConfigHandlerTest extends ConfigHandlerTestCase
     public function it_does_nothing_when_already_checked_out(): void
     {
         $this->git->getActiveBranchName()->willReturn('_hubkit');
-        $this->git->getRemoteDiffStatus('upstream', '_hubkit')->willReturn(Git::STATUS_UP_TO_DATE);
+        $this->git->getRemoteDiffStatus(REMOTE_MAIN, '_hubkit')->willReturn(Git::STATUS_UP_TO_DATE);
 
         $this->executeHandler();
 
@@ -53,7 +53,7 @@ final class EditConfigHandlerTest extends ConfigHandlerTestCase
     public function it_fails_with_already_existing_config_branch_outdated(): void
     {
         $this->git->branchExists('_hubkit')->willReturn(true);
-        $this->git->getRemoteDiffStatus('upstream', '_hubkit')->willReturn(Git::STATUS_DIVERGED);
+        $this->git->getRemoteDiffStatus(REMOTE_MAIN, '_hubkit')->willReturn(Git::STATUS_DIVERGED);
 
         $this->expectExceptionObject(new \RuntimeException('The remote "_hubkit" branch and local branch have diverged. Run the "sync-config" command first.'));
 
@@ -64,7 +64,7 @@ final class EditConfigHandlerTest extends ConfigHandlerTestCase
     public function it_fails_with_non_existing_config_branch(): void
     {
         $this->git->branchExists('_hubkit')->willReturn(false);
-        $this->git->remoteBranchExists('upstream', '_hubkit')->willReturn(false);
+        $this->git->remoteBranchExists(REMOTE_MAIN, '_hubkit')->willReturn(false);
 
         $this->expectExceptionObject(new \RuntimeException('The "_hubkit" branch does not exist yet. Run `init-config` first.'));
 
@@ -75,7 +75,7 @@ final class EditConfigHandlerTest extends ConfigHandlerTestCase
     public function it_fails_with_already_existing_remove_config_branch(): void
     {
         $this->git->branchExists('_hubkit')->willReturn(false);
-        $this->git->remoteBranchExists('upstream', '_hubkit')->willReturn(true);
+        $this->git->remoteBranchExists(REMOTE_MAIN, '_hubkit')->willReturn(true);
 
         $this->expectExceptionObject(new \RuntimeException(
             'The "_hubkit" branch exists remote, but the branch was not found locally.' . \PHP_EOL .
@@ -95,8 +95,8 @@ final class EditConfigHandlerTest extends ConfigHandlerTestCase
     public function it_fails_overwritten_ignored_files(array $gitIgnoreFiles, array $foundFiles = [], array $existingFiles = []): void
     {
         $this->git->branchExists('_hubkit')->willReturn(true);
-        $this->git->remoteBranchExists('upstream', '_hubkit')->willReturn(true);
-        $this->git->getRemoteDiffStatus('upstream', '_hubkit')->willReturn(Git::STATUS_UP_TO_DATE);
+        $this->git->remoteBranchExists(REMOTE_MAIN, '_hubkit')->willReturn(true);
+        $this->git->getRemoteDiffStatus(REMOTE_MAIN, '_hubkit')->willReturn(Git::STATUS_UP_TO_DATE);
 
         $this->filesystem->getCwd()->willReturn($cwd = ':/home/Jessie/project-name');
         $this->tempRepository->getLocal($cwd, '_hubkit')->willReturn($tempDirectory = ':/tmp/very-random-location-project');
@@ -192,8 +192,8 @@ final class EditConfigHandlerTest extends ConfigHandlerTestCase
     public function it_checks_out_config_branch(): void
     {
         $this->git->branchExists('_hubkit')->willReturn(true);
-        $this->git->remoteBranchExists('upstream', '_hubkit')->willReturn(true);
-        $this->git->getRemoteDiffStatus('upstream', '_hubkit')->willReturn(Git::STATUS_UP_TO_DATE);
+        $this->git->remoteBranchExists(REMOTE_MAIN, '_hubkit')->willReturn(true);
+        $this->git->getRemoteDiffStatus(REMOTE_MAIN, '_hubkit')->willReturn(Git::STATUS_UP_TO_DATE);
 
         $this->git->getActiveBranchName()->willReturn('master');
         $this->git->checkout('_hubkit')->shouldBeCalled();
@@ -213,7 +213,7 @@ final class EditConfigHandlerTest extends ConfigHandlerTestCase
             'The "_hubkit" configuration branch was checked out.',
             'Make sure to add and commit once you are done.',
             sprintf('After you are done run `git checkout %s`.', 'master'),
-            'And run the `sync-config` command to push the configuration to the upstream repository.',
+            'And run the `sync-config` command to push the configuration to the remote repository.',
         ]);
     }
 

--- a/tests/Handler/InitConfigHandlerTest.php
+++ b/tests/Handler/InitConfigHandlerTest.php
@@ -28,7 +28,7 @@ final class InitConfigHandlerTest extends ConfigHandlerTestCase
     public function it_fails_with_already_existing_config_branch(): void
     {
         $this->git->branchExists('_hubkit')->willReturn(true);
-        $this->git->getRemoteDiffStatus('upstream', '_hubkit')->willReturn(Git::STATUS_UP_TO_DATE);
+        $this->git->getRemoteDiffStatus(REMOTE_MAIN, '_hubkit')->willReturn(Git::STATUS_UP_TO_DATE);
 
         $this->expectExceptionObject(new \RuntimeException('The "_hubkit" branch already exists. Run `edit-config` instead.'));
 
@@ -39,7 +39,7 @@ final class InitConfigHandlerTest extends ConfigHandlerTestCase
     public function it_fails_with_already_existing_config_branch_outdated(): void
     {
         $this->git->branchExists('_hubkit')->willReturn(true);
-        $this->git->getRemoteDiffStatus('upstream', '_hubkit')->willReturn(Git::STATUS_DIVERGED);
+        $this->git->getRemoteDiffStatus(REMOTE_MAIN, '_hubkit')->willReturn(Git::STATUS_DIVERGED);
 
         $this->expectExceptionObject(new \RuntimeException('The remote "_hubkit" branch and local branch have diverged. Run the "sync-config" command first.'));
 
@@ -50,7 +50,7 @@ final class InitConfigHandlerTest extends ConfigHandlerTestCase
     public function it_fails_with_already_existing_remove_config_branch(): void
     {
         $this->git->branchExists('_hubkit')->willReturn(false);
-        $this->git->remoteBranchExists('upstream', '_hubkit')->willReturn(true);
+        $this->git->remoteBranchExists(REMOTE_MAIN, '_hubkit')->willReturn(true);
 
         $this->expectExceptionObject(new \RuntimeException(
             'The "_hubkit" branch exists remote, but the branch was not found locally.' . \PHP_EOL .
@@ -64,7 +64,7 @@ final class InitConfigHandlerTest extends ConfigHandlerTestCase
     public function it_it_fails_when_config_file_exists_as_ignored(): void
     {
         $this->git->branchExists('_hubkit')->willReturn(false);
-        $this->git->remoteBranchExists('upstream', '_hubkit')->willReturn(false);
+        $this->git->remoteBranchExists(REMOTE_MAIN, '_hubkit')->willReturn(false);
 
         $this->process->mustRun(['git', 'checkout', '--orphan', '_hubkit'])->shouldBeCalled();
         $this->process->mustRun(['git', 'rm', '-rf', '.'])->shouldBeCalled();
@@ -79,7 +79,7 @@ final class InitConfigHandlerTest extends ConfigHandlerTestCase
     public function it_it_generates_config_branch_with_repository_config(): void
     {
         $this->git->branchExists('_hubkit')->willReturn(false);
-        $this->git->remoteBranchExists('upstream', '_hubkit')->willReturn(false);
+        $this->git->remoteBranchExists(REMOTE_MAIN, '_hubkit')->willReturn(false);
 
         $this->process->mustRun(['git', 'checkout', '--orphan', '_hubkit'])->shouldBeCalled();
         $this->process->mustRun(['git', 'rm', '-rf', '.'])->shouldBeCalled();
@@ -125,7 +125,7 @@ final class InitConfigHandlerTest extends ConfigHandlerTestCase
         $this->github->getRepository()->willReturn('park-manager');
 
         $this->git->branchExists('_hubkit')->willReturn(false);
-        $this->git->remoteBranchExists('upstream', '_hubkit')->willReturn(false);
+        $this->git->remoteBranchExists(REMOTE_MAIN, '_hubkit')->willReturn(false);
 
         $this->process->mustRun(['git', 'checkout', '--orphan', '_hubkit'])->shouldBeCalled();
         $this->process->mustRun(['git', 'rm', '-rf', '.'])->shouldBeCalled();
@@ -185,7 +185,7 @@ final class InitConfigHandlerTest extends ConfigHandlerTestCase
     public function it_it_generates_config_branch_with_repository_config_and_mirrors_files(): void
     {
         $this->git->branchExists('_hubkit')->willReturn(false);
-        $this->git->remoteBranchExists('upstream', '_hubkit')->willReturn(false);
+        $this->git->remoteBranchExists(REMOTE_MAIN, '_hubkit')->willReturn(false);
 
         $this->process->mustRun(['git', 'checkout', '--orphan', '_hubkit'])->shouldBeCalled();
         $this->process->mustRun(['git', 'rm', '-rf', '.'])->shouldBeCalled();

--- a/tests/Handler/MergeHandlerTest.php
+++ b/tests/Handler/MergeHandlerTest.php
@@ -1623,12 +1623,12 @@ by who-else at 2014-11-23T14:50:24Z
     {
         $this->github->getComments(self::PR_NUMBER)->willReturn($notes);
 
-        $this->git->ensureNotesFetching('upstream')->shouldBeCalled();
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->ensureNotesFetching(REMOTE_MAIN)->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
         $this->git->addNotes($notesMessage ? PropArgument::containingString($notesMessage) : '', self::MERGE_SHA, 'github-comments')->shouldBeCalled();
 
         if ($notesMessage !== '') {
-            $this->git->pushToRemote('upstream', 'refs/notes/github-comments')->shouldBeCalled();
+            $this->git->pushToRemote(REMOTE_MAIN, 'refs/notes/github-comments')->shouldBeCalled();
         }
     }
 
@@ -1643,7 +1643,7 @@ by who-else at 2014-11-23T14:50:24Z
 
         if ($branchExists) {
             $this->git->checkout('master')->shouldBeCalled();
-            $this->git->pullRemote('upstream', 'master')->shouldBeCalled();
+            $this->git->pullRemote(REMOTE_MAIN, 'master')->shouldBeCalled();
         }
     }
 

--- a/tests/Handler/ReleaseHandlerTest.php
+++ b/tests/Handler/ReleaseHandlerTest.php
@@ -114,7 +114,7 @@ labels: removed-deprecation
     {
         $this->git = $this->prophesize(Git::class);
         $this->git->getActiveBranchName()->willReturn('master');
-        $this->git->ensureBranchInSync('upstream', 'master')->will(static function (): void {});
+        $this->git->ensureBranchInSync(REMOTE_MAIN, 'master')->will(static function (): void {});
 
         $this->github = $this->prophesize(GitHub::class);
         $this->github->getHostname()->willReturn('github.com');
@@ -258,7 +258,7 @@ labels: removed-deprecation
         $this->expectTags(['0.1.0', '1.0.0', '2.0.0']);
         $this->expectMatchingVersionBranchExists('3.0');
 
-        $this->git->ensureBranchInSync('upstream', '2.0')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.0')->shouldBeCalled();
         $this->git->getLogBetweenCommits('2.0.0', '2.0')->willReturn(self::COMMITS);
 
         $this->expectEditorReturns("### Added\n- Introduce a new API for ValuesBag");
@@ -427,12 +427,12 @@ labels: removed-deprecation
 
     private function expectMatchingVersionBranchExists(string $branch = '1.0'): void
     {
-        $this->git->remoteBranchExists('upstream', $branch)->willReturn(true);
+        $this->git->remoteBranchExists(REMOTE_MAIN, $branch)->willReturn(true);
     }
 
     private function expectMatchingVersionBranchNotExists(string $branch = '1.0'): void
     {
-        $this->git->remoteBranchExists('upstream', $branch)->willReturn(false);
+        $this->git->remoteBranchExists(REMOTE_MAIN, $branch)->willReturn(false);
     }
 
     private function expectTagAndGitHubRelease(string $version, string $message, ?string $title = null, ?string $branch = null): string
@@ -440,7 +440,7 @@ labels: removed-deprecation
         $this->branchSplitsh->syncTags($branch ?? 'master', $version)->willReturn(2)->shouldBeCalled();
 
         $this->process->mustRun(['git', 'tag', '-s', 'v' . $version, '-m', 'Release ' . $version])->shouldBeCalled();
-        $this->process->mustRun(['git', 'push', 'upstream', 'v' . $version])->shouldBeCalled();
+        $this->process->mustRun(['git', 'push', REMOTE_MAIN, 'v' . $version])->shouldBeCalled();
 
         $this->github->createRelease('v' . $version, $message, false, $title)->willReturn(
             ['html_url' => $url = 'https://github.com/park-manager/hubkit/releases/tag/v' . $version]

--- a/tests/Handler/SplitCreatedHandlerTest.php
+++ b/tests/Handler/SplitCreatedHandlerTest.php
@@ -43,7 +43,7 @@ final class SplitCreatedHandlerTest extends TestCase
     {
         $this->git = $this->prophesize(Git::class);
         $this->git->guardWorkingTreeReady()->shouldBeCalled();
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
         $this->git->getActiveBranchName()->willReturn('master');
 
         $this->github = $this->prophesize(GitHub::class);

--- a/tests/Handler/SplitRepoHandlerTest.php
+++ b/tests/Handler/SplitRepoHandlerTest.php
@@ -45,7 +45,7 @@ final class SplitRepoHandlerTest extends TestCase
     {
         $this->git = $this->prophesize(Git::class);
         $this->git->guardWorkingTreeReady()->shouldBeCalled();
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
         $this->git->getActiveBranchName()->willReturn('master');
 
         $this->github = $this->prophesize(GitHub::class);
@@ -117,7 +117,7 @@ final class SplitRepoHandlerTest extends TestCase
     /** @test */
     public function it_splits_with_current_branch(): void
     {
-        $this->git->checkoutRemoteBranch('upstream', 'master')->shouldNotBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, 'master')->shouldNotBeCalled();
         $this->splitshGit->splitBranch('master')->willReturn(['core' => ['42431142', 'url']]);
 
         $args = $this->getArgs();
@@ -134,7 +134,7 @@ final class SplitRepoHandlerTest extends TestCase
     /** @test */
     public function it_dry_splits_with_current_branch(): void
     {
-        $this->git->checkoutRemoteBranch('upstream', 'master')->shouldNotBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, 'master')->shouldNotBeCalled();
         $this->splitshGit->drySplitBranch('master')->willReturn(2);
 
         $args = $this->getArgs();
@@ -153,7 +153,7 @@ final class SplitRepoHandlerTest extends TestCase
     /** @test */
     public function it_splits_specific_branch(): void
     {
-        $this->git->checkoutRemoteBranch('upstream', '2.0')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.0')->shouldBeCalled();
         $this->splitshGit->splitBranch('2.0')->willReturn(['core' => ['42431142', 'url']]);
 
         $args = $this->getArgs();
@@ -171,7 +171,7 @@ final class SplitRepoHandlerTest extends TestCase
     /** @test */
     public function it_splits_at_specific_prefix(): void
     {
-        $this->git->checkoutRemoteBranch('upstream', 'master')->shouldNotBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, 'master')->shouldNotBeCalled();
         $this->splitshGit->splitAtPrefix('master', 'src/Module/CoreModule')->willReturn(['core' => ['42431142', 'url']]);
 
         $args = $this->getArgs();
@@ -189,7 +189,7 @@ final class SplitRepoHandlerTest extends TestCase
     /** @test */
     public function it_dry_splits_at_specific_prefix(): void
     {
-        $this->git->checkoutRemoteBranch('upstream', 'master')->shouldNotBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, 'master')->shouldNotBeCalled();
         $this->splitshGit->drySplitAtPrefix('master', 'src/Module/CoreModule')->shouldBeCalled();
 
         $args = $this->getArgs();

--- a/tests/Handler/SwitchBaseHandlerTest.php
+++ b/tests/Handler/SwitchBaseHandlerTest.php
@@ -106,7 +106,7 @@ final class SwitchBaseHandlerTest extends TestCase
     /** @test */
     public function it_does_not_switch_to_non_existent_base(): void
     {
-        $this->git->remoteBranchExists('upstream', '2.0')->willReturn(false);
+        $this->git->remoteBranchExists(REMOTE_MAIN, '2.0')->willReturn(false);
         $this->github->getPullRequest(12)->willReturn([
             'state' => 'open',
             'base' => [
@@ -124,7 +124,7 @@ final class SwitchBaseHandlerTest extends TestCase
     public function it_does_not_switch_when_wc_is_not_ready(): void
     {
         $this->git->isWorkingTreeReady()->willReturn(false);
-        $this->git->remoteBranchExists('upstream', '2.0')->willReturn(true);
+        $this->git->remoteBranchExists(REMOTE_MAIN, '2.0')->willReturn(true);
         $this->github->getPullRequest(12)->willReturn([
             'state' => 'open',
             'base' => [
@@ -165,10 +165,10 @@ final class SwitchBaseHandlerTest extends TestCase
         $this->expectWorkingTreeReady();
         $this->git->getActiveBranchName()->willReturn('main');
 
-        $this->git->remoteBranchExists('upstream', '2.0')->will(self::trackReturn(Git::class, true));
+        $this->git->remoteBranchExists(REMOTE_MAIN, '2.0')->will(self::trackReturn(Git::class, true));
         $this->git->ensureRemoteExists('sstok', 'git://github.com/sstok/hupkit.git')->will(self::trackNoReturn(Git::class));
         $this->git->remoteUpdate('sstok')->will(self::trackNoReturn(Git::class));
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
         $this->git->getGitDirectory()->willReturn($gitDir = '/:local');
         $this->filesystem->fileExists($gitDir . '/.hubkit-switch')->will(self::trackReturn(Filesystem::class, false));
@@ -182,7 +182,7 @@ final class SwitchBaseHandlerTest extends TestCase
         $this->git->checkout($tmpBranch, true)->will(self::trackNoReturn(Git::class));
         $this->filesystem->dumpFile($gitDir . '/.hubkit-switch', $tmpBranch)->will(self::trackNoReturn(Filesystem::class));
 
-        $this->process->mustRun(['git', 'rebase', '--onto', 'upstream/2.0', 'upstream/main', $tmpBranch])->will(self::trackReturn(CliProcess::class, $this->createMock(Process::class)));
+        $this->process->mustRun(['git', 'rebase', '--onto', REMOTE_MAIN . '/2.0', REMOTE_MAIN . '/main', $tmpBranch])->will(self::trackReturn(CliProcess::class, $this->createMock(Process::class)));
         $this->git->checkout('main')->will(self::trackNoReturn(Git::class));
 
         // Apply changes
@@ -197,7 +197,7 @@ final class SwitchBaseHandlerTest extends TestCase
 
         // Ensure all calls where made in the correct order.
         self::assertSame([
-            [Git::class, 'remoteBranchExists', ['upstream', '2.0']],
+            [Git::class, 'remoteBranchExists', [REMOTE_MAIN, '2.0']],
             [Git::class, 'ensureRemoteExists', ['sstok', 'git://github.com/sstok/hupkit.git']],
             [Git::class, 'remoteUpdate', ['sstok']],
             [Filesystem::class, 'fileExists', ['/:local/.hubkit-switch']],
@@ -206,7 +206,7 @@ final class SwitchBaseHandlerTest extends TestCase
             [Git::class, 'checkoutRemoteBranch', ['sstok', 'bug/new-feature-1', false]],
             [Git::class, 'checkout', ['_temp/sstok--bug/new-feature-1--2.0', true]],
             [Filesystem::class, 'dumpFile', ['/:local/.hubkit-switch', '_temp/sstok--bug/new-feature-1--2.0']],
-            [CliProcess::class, 'mustRun', [['git', 'rebase', '--onto', 'upstream/2.0', 'upstream/main', '_temp/sstok--bug/new-feature-1--2.0']]],
+            [CliProcess::class, 'mustRun', [['git', 'rebase', '--onto', REMOTE_MAIN . '/2.0', REMOTE_MAIN . '/main', '_temp/sstok--bug/new-feature-1--2.0']]],
             [Git::class, 'checkout', ['main']],
             [CliProcess::class, 'mustRun', [['git', 'push', '--force', 'sstok', '_temp/sstok--bug/new-feature-1--2.0:bug/new-feature-1'], 'Push failed (access disabled?)']],
             [CliProcess::class, 'run', [['git', 'branch', '-D', '_temp/sstok--bug/new-feature-1--2.0']]],
@@ -256,10 +256,10 @@ final class SwitchBaseHandlerTest extends TestCase
         $this->expectWorkingTreeReady();
         $this->git->getActiveBranchName()->willReturn('main');
 
-        $this->git->remoteBranchExists('upstream', '2.0')->will(self::trackReturn(Git::class, true));
+        $this->git->remoteBranchExists(REMOTE_MAIN, '2.0')->will(self::trackReturn(Git::class, true));
         $this->git->ensureRemoteExists('sstok', 'git://github.com/sstok/hupkit.git')->will(self::trackNoReturn(Git::class));
         $this->git->remoteUpdate('sstok')->will(self::trackNoReturn(Git::class));
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
         $this->git->getGitDirectory()->willReturn($gitDir = '/:local');
         $this->filesystem->fileExists($gitDir . '/.hubkit-switch')->will(self::trackReturn(Filesystem::class, true));
@@ -299,10 +299,10 @@ final class SwitchBaseHandlerTest extends TestCase
         $this->expectWorkingTreeReady();
         $this->git->getActiveBranchName()->willReturn('main');
 
-        $this->git->remoteBranchExists('upstream', '2.0')->will(self::trackReturn(Git::class, true));
+        $this->git->remoteBranchExists(REMOTE_MAIN, '2.0')->will(self::trackReturn(Git::class, true));
         $this->git->ensureRemoteExists('sstok', 'git://github.com/sstok/hupkit.git')->will(self::trackNoReturn(Git::class));
         $this->git->remoteUpdate('sstok')->will(self::trackNoReturn(Git::class));
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
         $this->git->getGitDirectory()->willReturn($gitDir = '/:local');
         $this->filesystem->fileExists($gitDir . '/.hubkit-switch')->will(self::trackReturn(Filesystem::class, true));
@@ -317,7 +317,7 @@ final class SwitchBaseHandlerTest extends TestCase
         $this->git->checkout($tmpBranch, true)->will(self::trackNoReturn(Git::class));
         $this->filesystem->dumpFile($gitDir . '/.hubkit-switch', $tmpBranch)->will(self::trackNoReturn(Filesystem::class));
 
-        $this->process->mustRun(['git', 'rebase', '--onto', 'upstream/2.0', 'upstream/main', $tmpBranch])->will(self::trackReturn(CliProcess::class, $this->createMock(Process::class)));
+        $this->process->mustRun(['git', 'rebase', '--onto', REMOTE_MAIN . '/2.0', REMOTE_MAIN . '/main', $tmpBranch])->will(self::trackReturn(CliProcess::class, $this->createMock(Process::class)));
         $this->git->checkout('main')->will(self::trackNoReturn(Git::class));
 
         // Apply changes
@@ -339,7 +339,7 @@ final class SwitchBaseHandlerTest extends TestCase
 
         // Ensure all calls where made in the correct order.
         self::assertSame([
-            [Git::class, 'remoteBranchExists', ['upstream', '2.0']],
+            [Git::class, 'remoteBranchExists', [REMOTE_MAIN, '2.0']],
             [Git::class, 'ensureRemoteExists', ['sstok', 'git://github.com/sstok/hupkit.git']],
             [Git::class, 'remoteUpdate', ['sstok']],
             [Filesystem::class, 'fileExists', ['/:local/.hubkit-switch']],
@@ -349,7 +349,7 @@ final class SwitchBaseHandlerTest extends TestCase
             [Git::class, 'checkoutRemoteBranch', ['sstok', 'bug/new-feature-1', false]],
             [Git::class, 'checkout', ['_temp/sstok--bug/new-feature-1--2.0', true]],
             [Filesystem::class, 'dumpFile', ['/:local/.hubkit-switch', '_temp/sstok--bug/new-feature-1--2.0']],
-            [CliProcess::class, 'mustRun', [['git', 'rebase', '--onto', 'upstream/2.0', 'upstream/main', '_temp/sstok--bug/new-feature-1--2.0']]],
+            [CliProcess::class, 'mustRun', [['git', 'rebase', '--onto', REMOTE_MAIN . '/2.0', REMOTE_MAIN . '/main', '_temp/sstok--bug/new-feature-1--2.0']]],
             [Git::class, 'checkout', ['main']],
             [CliProcess::class, 'mustRun', [['git', 'push', '--force', 'sstok', '_temp/sstok--bug/new-feature-1--2.0:bug/new-feature-1'], 'Push failed (access disabled?)']],
             [CliProcess::class, 'run', [['git', 'branch', '-D', '_temp/sstok--bug/new-feature-1--2.0']]],
@@ -399,10 +399,10 @@ final class SwitchBaseHandlerTest extends TestCase
         $this->expectWorkingTreeReady();
         $this->git->getActiveBranchName()->willReturn('main');
 
-        $this->git->remoteBranchExists('upstream', '2.0')->will(self::trackReturn(Git::class, true));
+        $this->git->remoteBranchExists(REMOTE_MAIN, '2.0')->will(self::trackReturn(Git::class, true));
         $this->git->ensureRemoteExists('sstok', 'git://github.com/sstok/hupkit.git')->will(self::trackNoReturn(Git::class));
         $this->git->remoteUpdate('sstok')->will(self::trackNoReturn(Git::class));
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
         $this->git->getGitDirectory()->willReturn($gitDir = '/:local');
         $this->filesystem->fileExists($gitDir . '/.hubkit-switch')->will(self::trackReturn(Filesystem::class, true));
@@ -420,7 +420,7 @@ final class SwitchBaseHandlerTest extends TestCase
         $this->git->checkout($tmpBranch, true)->will(self::trackNoReturn(Git::class));
         $this->filesystem->dumpFile($gitDir . '/.hubkit-switch', $tmpBranch)->will(self::trackNoReturn(Filesystem::class));
 
-        $this->process->mustRun(['git', 'rebase', '--onto', 'upstream/2.0', 'upstream/main', $tmpBranch])->will(self::trackReturn(CliProcess::class, $this->createMock(Process::class)));
+        $this->process->mustRun(['git', 'rebase', '--onto', REMOTE_MAIN . '/2.0', REMOTE_MAIN . '/main', $tmpBranch])->will(self::trackReturn(CliProcess::class, $this->createMock(Process::class)));
         $this->git->checkout('main')->will(self::trackNoReturn(Git::class));
 
         // Apply changes
@@ -442,7 +442,7 @@ final class SwitchBaseHandlerTest extends TestCase
 
         // Ensure all calls where made in the correct order.
         self::assertSame([
-            [Git::class, 'remoteBranchExists', ['upstream', '2.0']],
+            [Git::class, 'remoteBranchExists', [REMOTE_MAIN, '2.0']],
             [Git::class, 'ensureRemoteExists', ['sstok', 'git://github.com/sstok/hupkit.git']],
             [Git::class, 'remoteUpdate', ['sstok']],
             [Filesystem::class, 'fileExists', ['/:local/.hubkit-switch']],
@@ -454,7 +454,7 @@ final class SwitchBaseHandlerTest extends TestCase
             [Git::class, 'checkoutRemoteBranch', ['sstok', 'bug/new-feature-1', false]],
             [Git::class, 'checkout', ['_temp/sstok--bug/new-feature-1--2.0', true]],
             [Filesystem::class, 'dumpFile', ['/:local/.hubkit-switch', '_temp/sstok--bug/new-feature-1--2.0']],
-            [CliProcess::class, 'mustRun', [['git', 'rebase', '--onto', 'upstream/2.0', 'upstream/main', '_temp/sstok--bug/new-feature-1--2.0']]],
+            [CliProcess::class, 'mustRun', [['git', 'rebase', '--onto', REMOTE_MAIN . '/2.0', REMOTE_MAIN . '/main', '_temp/sstok--bug/new-feature-1--2.0']]],
             [Git::class, 'checkout', ['main']],
             [CliProcess::class, 'mustRun', [['git', 'push', '--force', 'sstok', '_temp/sstok--bug/new-feature-1--2.0:bug/new-feature-1'], 'Push failed (access disabled?)']],
             [CliProcess::class, 'run', [['git', 'branch', '-D', '_temp/sstok--bug/new-feature-1--2.0']]],
@@ -504,10 +504,10 @@ final class SwitchBaseHandlerTest extends TestCase
         $this->expectWorkingTreeReady();
         $this->git->getActiveBranchName()->willReturn('main');
 
-        $this->git->remoteBranchExists('upstream', '2.0')->will(self::trackReturn(Git::class, true));
+        $this->git->remoteBranchExists(REMOTE_MAIN, '2.0')->will(self::trackReturn(Git::class, true));
         $this->git->ensureRemoteExists('sstok', 'git://github.com/sstok/hupkit.git')->will(self::trackNoReturn(Git::class));
         $this->git->remoteUpdate('sstok')->will(self::trackNoReturn(Git::class));
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
         $this->git->getGitDirectory()->willReturn($gitDir = '/:local');
         $this->filesystem->fileExists($gitDir . '/.hubkit-switch')->will(self::trackReturn(Filesystem::class, true));
@@ -525,7 +525,7 @@ final class SwitchBaseHandlerTest extends TestCase
         $this->git->checkout($tmpBranch, true)->will(self::trackNoReturn(Git::class));
         $this->filesystem->dumpFile($gitDir . '/.hubkit-switch', $tmpBranch)->will(self::trackNoReturn(Filesystem::class));
 
-        $this->process->mustRun(['git', 'rebase', '--onto', 'upstream/2.0', 'upstream/main', $tmpBranch])->will(self::trackReturn(CliProcess::class, $this->createMock(Process::class)));
+        $this->process->mustRun(['git', 'rebase', '--onto', REMOTE_MAIN . '/2.0', REMOTE_MAIN . '/main', $tmpBranch])->will(self::trackReturn(CliProcess::class, $this->createMock(Process::class)));
         $this->git->checkout('main')->will(self::trackNoReturn(Git::class));
 
         // Apply changes
@@ -547,7 +547,7 @@ final class SwitchBaseHandlerTest extends TestCase
 
         // Ensure all calls where made in the correct order.
         self::assertSame([
-            [Git::class, 'remoteBranchExists', ['upstream', '2.0']],
+            [Git::class, 'remoteBranchExists', [REMOTE_MAIN, '2.0']],
             [Git::class, 'ensureRemoteExists', ['sstok', 'git://github.com/sstok/hupkit.git']],
             [Git::class, 'remoteUpdate', ['sstok']],
             [Filesystem::class, 'fileExists', ['/:local/.hubkit-switch']],
@@ -561,7 +561,7 @@ final class SwitchBaseHandlerTest extends TestCase
             [Git::class, 'checkoutRemoteBranch', ['sstok', 'bug/new-feature-1', false]],
             [Git::class, 'checkout', ['_temp/sstok--bug/new-feature-1--2.0', true]],
             [Filesystem::class, 'dumpFile', ['/:local/.hubkit-switch', '_temp/sstok--bug/new-feature-1--2.0']],
-            [CliProcess::class, 'mustRun', [['git', 'rebase', '--onto', 'upstream/2.0', 'upstream/main', '_temp/sstok--bug/new-feature-1--2.0']]],
+            [CliProcess::class, 'mustRun', [['git', 'rebase', '--onto', REMOTE_MAIN . '/2.0', REMOTE_MAIN . '/main', '_temp/sstok--bug/new-feature-1--2.0']]],
             [Git::class, 'checkout', ['main']],
             [CliProcess::class, 'mustRun', [['git', 'push', '--force', 'sstok', '_temp/sstok--bug/new-feature-1--2.0:bug/new-feature-1'], 'Push failed (access disabled?)']],
             [CliProcess::class, 'run', [['git', 'branch', '-D', '_temp/sstok--bug/new-feature-1--2.0']]],

--- a/tests/Handler/UpMergeHandlerTest.php
+++ b/tests/Handler/UpMergeHandlerTest.php
@@ -81,17 +81,17 @@ final class UpMergeHandlerTest extends TestCase
     public function it_merges_current_branch_into_next_version_branch(): void
     {
         $this->git->getActiveBranchName()->willReturn('2.3');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6']);
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6']);
 
-        $this->git->ensureBranchInSync('upstream', '2.3')->shouldBeCalled();
-        $this->git->checkoutRemoteBranch('upstream', '2.5')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.5')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.3')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.5')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.5')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.5'])->shouldBeCalled();
+        $this->git->pushToRemote(REMOTE_MAIN, ['2.5'])->shouldBeCalled();
 
         $this->branchSplitsh->splitBranch('2.5')->willReturn([]);
 
@@ -106,17 +106,17 @@ final class UpMergeHandlerTest extends TestCase
         $this->expectConfigHasSplits();
 
         $this->git->getActiveBranchName()->willReturn('2.3');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6']);
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6']);
 
-        $this->git->ensureBranchInSync('upstream', '2.3')->shouldBeCalled();
-        $this->git->checkoutRemoteBranch('upstream', '2.5')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.5')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.3')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.5')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.5')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.5'])->shouldBeCalled();
+        $this->git->pushToRemote(REMOTE_MAIN, ['2.5'])->shouldBeCalled();
 
         $this->executeHandler($this->getArgs()->setOption('no-split', true));
 
@@ -127,17 +127,17 @@ final class UpMergeHandlerTest extends TestCase
     public function it_merges_current_branch_into_next_relative_version_branch(): void
     {
         $this->git->getActiveBranchName()->willReturn('2.3');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.x']);
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.x']);
 
-        $this->git->ensureBranchInSync('upstream', '2.3')->shouldBeCalled();
-        $this->git->checkoutRemoteBranch('upstream', '2.x')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.x')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.3')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.x')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.x')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.x'])->shouldBeCalled();
+        $this->git->pushToRemote(REMOTE_MAIN, ['2.x'])->shouldBeCalled();
 
         $this->branchSplitsh->splitBranch('2.x')->willReturn([]);
 
@@ -150,17 +150,17 @@ final class UpMergeHandlerTest extends TestCase
     public function it_merges_to_master_when_current_branch_is_last_version(): void
     {
         $this->git->getActiveBranchName()->willReturn('2.6');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6']);
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6']);
 
-        $this->git->ensureBranchInSync('upstream', '2.6')->shouldBeCalled();
-        $this->git->checkoutRemoteBranch('upstream', 'master')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', 'master')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.6')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, 'master')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, 'master')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.6'])->shouldBeCalled();
 
         $this->git->checkout('2.6')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['master'])->shouldBeCalled();
+        $this->git->pushToRemote(REMOTE_MAIN, ['master'])->shouldBeCalled();
 
         $this->branchSplitsh->splitBranch('master')->willReturn([]);
 
@@ -173,8 +173,8 @@ final class UpMergeHandlerTest extends TestCase
     public function it_does_nothing_when_current_branch_is_not_a_version(): void
     {
         $this->git->getActiveBranchName()->willReturn('master');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6']);
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6']);
 
         $this->executeHandler();
     }
@@ -182,18 +182,18 @@ final class UpMergeHandlerTest extends TestCase
     /** @test */
     public function it_merges_custom_branch_into_next_version_branch(): void
     {
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6']);
-        $this->git->checkoutRemoteBranch('upstream', '2.3')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.3')->shouldBeCalled();
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6']);
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.3')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.3')->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', '2.5')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.5')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.5')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.5')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.5'])->shouldBeCalled();
+        $this->git->pushToRemote(REMOTE_MAIN, ['2.5'])->shouldBeCalled();
 
         $this->branchSplitsh->splitBranch('2.5')->willReturn([]);
 
@@ -208,30 +208,30 @@ final class UpMergeHandlerTest extends TestCase
     public function it_merges_current_branch_into_next_version_branches(): void
     {
         $this->git->getActiveBranchName()->willReturn('2.3');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6', '2.x']);
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6', '2.x']);
 
-        $this->git->ensureBranchInSync('upstream', '2.3')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.3')->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', '2.5')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.5')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.5')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.5')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', '2.6')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.6')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.6')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.6')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.5'])->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', '2.x')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.x')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.x')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.x')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.6'])->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', 'master')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', 'master')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, 'master')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, 'master')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.x'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.5', '2.6', '2.x', 'master'])->shouldBeCalled();
+        $this->git->pushToRemote(REMOTE_MAIN, ['2.5', '2.6', '2.x', 'master'])->shouldBeCalled();
 
         foreach (['2.5', '2.6', '2.x', 'master'] as $branchTarget) {
             $this->branchSplitsh->splitBranch($branchTarget)->willReturn([]);
@@ -257,30 +257,30 @@ final class UpMergeHandlerTest extends TestCase
         }
 
         $this->git->getActiveBranchName()->willReturn('2.3');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6', '2.x']);
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6', '2.x']);
 
-        $this->git->ensureBranchInSync('upstream', '2.3')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.3')->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', '2.5')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.5')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.5')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.5')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', '2.6')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.6')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.6')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.6')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.5'])->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', '2.x')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.x')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.x')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.x')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.6'])->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', 'master')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', 'master')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, 'master')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, 'master')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.x'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.5', '2.6', '2.x', 'master'])->shouldBeCalled();
+        $this->git->pushToRemote(REMOTE_MAIN, ['2.5', '2.6', '2.x', 'master'])->shouldBeCalled();
 
         $this->executeHandler($this->getArgs()->setOption('all', true));
 
@@ -298,30 +298,30 @@ final class UpMergeHandlerTest extends TestCase
         $this->expectConfigHasSplits();
 
         $this->git->getActiveBranchName()->willReturn('2.3');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6', '2.x']);
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6', '2.x']);
 
-        $this->git->ensureBranchInSync('upstream', '2.3')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.3')->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', '2.5')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.5')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.5')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.5')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', '2.6')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.6')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.6')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.6')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.5'])->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', '2.x')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.x')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.x')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.x')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.6'])->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', 'master')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', 'master')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, 'master')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, 'master')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.x'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.5', '2.6', '2.x', 'master'])->shouldBeCalled();
+        $this->git->pushToRemote(REMOTE_MAIN, ['2.5', '2.6', '2.x', 'master'])->shouldBeCalled();
 
         $this->executeHandler($this->getArgs()->setOption('all', true)->setOption('no-split', true));
 
@@ -337,8 +337,8 @@ final class UpMergeHandlerTest extends TestCase
     public function it_does_nothing_with_all_when_current_branch_is_not_a_version(): void
     {
         $this->git->getActiveBranchName()->willReturn('master');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6']);
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6']);
 
         self::assertSame(1, $this->executeHandler($this->getArgs()->setOption('all', true)));
 
@@ -361,9 +361,9 @@ final class UpMergeHandlerTest extends TestCase
         $this->config->setActiveRepository('github.com', 'park-manager/hubkit');
 
         $this->git->getActiveBranchName()->willReturn('2.6');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6']);
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6']);
 
         $this->executeHandler();
 
@@ -373,11 +373,11 @@ final class UpMergeHandlerTest extends TestCase
     /** @test */
     public function error_message_contains_original_exception_message(): void
     {
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6']);
-        $this->git->checkoutRemoteBranch('upstream', '2.3')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.3')->willThrow(
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6']);
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.3')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.3')->willThrow(
             new \RuntimeException('Local branch is not up-to-date.')
         );
 
@@ -393,20 +393,20 @@ final class UpMergeHandlerTest extends TestCase
         $this->git->checkout('1.3')->shouldBeCalled();
 
         $this->git->getActiveBranchName()->willReturn('1.3');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['1.3', '2.2', '2.3', '2.5', '2.6', '2.x', '3.0']);
-        $this->git->ensureBranchInSync('upstream', '1.3')->shouldBeCalled();
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['1.3', '2.2', '2.3', '2.5', '2.6', '2.x', '3.0']);
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '1.3')->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', '3.0')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '3.0')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '3.0')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '3.0')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '1.3'])->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', 'master')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', 'master')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, 'master')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, 'master')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '3.0'])->shouldBeCalled();
 
-        $this->git->pushToRemote('upstream', ['3.0', 'master'])->shouldBeCalled();
+        $this->git->pushToRemote(REMOTE_MAIN, ['3.0', 'master'])->shouldBeCalled();
 
         foreach (['3.0', 'master'] as $branchTarget) {
             $this->branchSplitsh->splitBranch($branchTarget)->willReturn([]);
@@ -430,9 +430,9 @@ final class UpMergeHandlerTest extends TestCase
         $this->expectConfigHasUpmergeDisabled();
 
         $this->git->getActiveBranchName()->willReturn('2.6');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6']);
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6']);
 
         self::assertSame(1, $this->executeHandler());
 
@@ -443,11 +443,11 @@ final class UpMergeHandlerTest extends TestCase
     public function it_dry_merges_current_branch_into_next_version_branch(): void
     {
         $this->git->getActiveBranchName()->willReturn('2.3');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6']);
-        $this->git->ensureBranchInSync('upstream', '2.3')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.5')->shouldBeCalled();
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6']);
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.3')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.5')->shouldBeCalled();
 
         $this->branchSplitsh->drySplitBranch('2.5')->shouldBeCalled();
 
@@ -460,14 +460,14 @@ final class UpMergeHandlerTest extends TestCase
     public function it_dry_merges_current_branch_into_next_version_branches(): void
     {
         $this->git->getActiveBranchName()->willReturn('2.3');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6', '2.x']);
-        $this->git->ensureBranchInSync('upstream', '2.3')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.5')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.6')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.x')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', 'master')->shouldBeCalled();
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6', '2.x']);
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.3')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.5')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.6')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.x')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, 'master')->shouldBeCalled();
 
         $this->branchSplitsh->drySplitBranch('2.5')->shouldBeCalled();
         $this->branchSplitsh->drySplitBranch('2.6')->shouldBeCalled();
@@ -500,26 +500,26 @@ final class UpMergeHandlerTest extends TestCase
         $this->config->setActiveRepository('github.com', 'park-manager/hubkit');
 
         $this->git->getActiveBranchName()->willReturn('2.3');
-        $this->git->remoteUpdate('upstream')->shouldBeCalled();
+        $this->git->remoteUpdate(REMOTE_MAIN)->shouldBeCalled();
 
-        $this->git->getVersionBranches('upstream')->willReturn(['2.2', '2.3', '2.5', '2.6', '2.x']);
+        $this->git->getVersionBranches(REMOTE_MAIN)->willReturn(['2.2', '2.3', '2.5', '2.6', '2.x']);
 
-        $this->git->ensureBranchInSync('upstream', '2.3')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.3')->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', '2.5')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.5')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.5')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.5')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.3'])->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', '2.6')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.6')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.6')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.6')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.5'])->shouldBeCalled();
 
-        $this->git->checkoutRemoteBranch('upstream', '2.x')->shouldBeCalled();
-        $this->git->ensureBranchInSync('upstream', '2.x')->shouldBeCalled();
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '2.x')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.x')->shouldBeCalled();
         $this->process->mustRun(['git', 'merge', '--no-ff', '--log', '2.6'])->shouldBeCalled();
 
         $this->git->checkout('2.3')->shouldBeCalled();
-        $this->git->pushToRemote('upstream', ['2.5', '2.6', '2.x'])->shouldBeCalled();
+        $this->git->pushToRemote(REMOTE_MAIN, ['2.5', '2.6', '2.x'])->shouldBeCalled();
 
         $this->branchSplitsh->splitBranch('2.5')->willReturn([]);
         $this->branchSplitsh->splitBranch('2.6')->willReturn([]);

--- a/tests/RemotesConfigParserTest.php
+++ b/tests/RemotesConfigParserTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HuPKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Tests;
+
+use HubKit\RemotesConfigParser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class RemotesConfigParserTest extends TestCase
+{
+    /** @test */
+    public function it_parses_a_config_file(): void
+    {
+        self::assertEquals([], RemotesConfigParser::parse(''));
+        self::assertEquals([], RemotesConfigParser::parse('; Comment'));
+        self::assertEquals([], RemotesConfigParser::parse(';root=origin'));
+        self::assertEquals(['main' => 'upstream'], RemotesConfigParser::parse('main=upstream'));
+        self::assertEquals(['main' => 'upstream'], RemotesConfigParser::parse('main = upstream'));
+        self::assertEquals(['main' => 'upstream'], RemotesConfigParser::parse("main = upstream\n"));
+        self::assertEquals(['main' => 'upstream'], RemotesConfigParser::parse("\nmain = upstream\n"));
+        self::assertEquals(['main' => 'upstream'], RemotesConfigParser::parse("; Comment \nmain = upstream"));
+        self::assertEquals(['main' => 'upstream', 'fork' => 'origin'], RemotesConfigParser::parse("; Comment \nmain = upstream\nfork= origin"));
+    }
+
+    /** @test */
+    public function it_only_accepts_main_or_fork_variables(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to process file ".hk_remotes" at line 2, declaration foo is not accepted, only "main" or "fork".');
+
+        RemotesConfigParser::parse("\nfoo=bar");
+    }
+
+    /** @test */
+    public function it_rejects_overwrites(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to process file ".hk_remotes" at line 3, declaration main already set.');
+
+        RemotesConfigParser::parse("\nmain=bar\nmain=foo");
+    }
+
+    /** @test */
+    public function it_does_not_accept_comments_at_declaration(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Unable to process file ".hk_remotes" at line %d, expected declaration (`name=value` or `name=va_lue`), empty line or comment (`; comment`), got: %s', 1, 'foo=bar; Comment'));
+
+        RemotesConfigParser::parse('foo=bar; Comment');
+    }
+}

--- a/tests/Service/BranchSplitshTest.php
+++ b/tests/Service/BranchSplitshTest.php
@@ -127,7 +127,7 @@ final class BranchSplitshTest extends TestCase
     /** @test */
     public function splits_prefix_to_destinations_with_no_explicit_config(): void
     {
-        $this->git->ensureBranchInSync('upstream', '4.0')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '4.0')->shouldBeCalled();
         $this->expectGitSplit('src/Module/CoreModule', 'git@github.com:hubkit-sandbox/core-module.git', 'cc1', '4.0');
 
         self::assertEquals(
@@ -162,7 +162,7 @@ final class BranchSplitshTest extends TestCase
     /** @test */
     public function splits_prefix_to_destinations_with_explicit_config(): void
     {
-        $this->git->ensureBranchInSync('upstream', '2.1')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.1')->shouldBeCalled();
         $this->expectGitSplit('lobster', 'git@github.com:hubkit-sandbox/pinchy.git', 'cc1', '2.1');
 
         self::assertEquals(
@@ -181,7 +181,7 @@ final class BranchSplitshTest extends TestCase
     /** @test */
     public function split_prefix_to_destinations_fails_for_missing_prefix_configuration(): void
     {
-        $this->git->ensureBranchInSync('upstream', '4.1')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '4.1')->shouldBeCalled();
 
         $this->expectExceptionObject(new \InvalidArgumentException(
             'Unable to split repository at prefix: No entry found for "[repositories][github.com][repos][hubkit-sandbox/empire][branches][:default][split][pinchy]".'
@@ -193,7 +193,7 @@ final class BranchSplitshTest extends TestCase
     /** @test */
     public function splits_branch_to_destinations_with_no_explicit_config(): void
     {
-        $this->git->ensureBranchInSync('upstream', '4.0')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '4.0')->shouldBeCalled();
         $this->expectGitSplit('src/Module/CoreModule', 'git@github.com:hubkit-sandbox/core-module.git', 'cc1', '4.0');
         $this->expectGitSplit('src/Module/WebhostingModule', 'git@github.com:hubkit-sandbox/webhosting-module.git', 'cc2', '4.0');
 
@@ -216,7 +216,7 @@ final class BranchSplitshTest extends TestCase
     /** @test */
     public function splits_branch_to_destinations_with_explicit_config(): void
     {
-        $this->git->ensureBranchInSync('upstream', '2.1')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.1')->shouldBeCalled();
         $this->expectGitSplit('src/Module/CoreModule', 'git@github.com:hubkit-sandbox/core-module.git', 'cc1', '2.1');
         $this->expectGitSplit('src/Module/WebhostingModule', 'git@github.com:hubkit-sandbox/webhosting-module.git', 'cc2', '2.1');
         $this->expectGitSplit('lobster', 'git@github.com:hubkit-sandbox/pinchy.git', 'cc3', '2.1');
@@ -242,7 +242,7 @@ final class BranchSplitshTest extends TestCase
     /** @test */
     public function splits_branch_to_destinations_with_explicit_config2(): void
     {
-        $this->git->ensureBranchInSync('upstream', 'master')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, 'master')->shouldBeCalled();
         $this->expectGitSplit('src/Module/CoreModule', 'git@github.com:hubkit-sandbox/core-module.git', 'cc1');
         $this->expectGitSplit('src/Module/WebhostingModule', 'git@github.com:hubkit-sandbox/webhosting-module.git', 'cc2');
         $this->expectGitSplit('docs', 'git@github.com:hubkit-sandbox/docs.git', 'cc3');
@@ -295,7 +295,7 @@ final class BranchSplitshTest extends TestCase
     /** @test */
     public function dry_splits_prefix_to_destinations_with_no_explicit_config(): void
     {
-        $this->git->ensureBranchInSync('upstream', '4.0')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '4.0')->shouldBeCalled();
         $this->expectNoSplitPerformed();
 
         $this->getBranchSplitsh()->drySplitAtPrefix('4.0', 'src/Module/CoreModule');
@@ -309,7 +309,7 @@ final class BranchSplitshTest extends TestCase
     /** @test */
     public function dry_splits_prefix_to_destinations_with_explicit_config(): void
     {
-        $this->git->ensureBranchInSync('upstream', '2.1')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.1')->shouldBeCalled();
         $this->expectNoSplitPerformed();
 
         $this->getBranchSplitsh()->drySplitAtPrefix('2.1', 'lobster');
@@ -323,7 +323,7 @@ final class BranchSplitshTest extends TestCase
     /** @test */
     public function dry_split_prefix_to_destinations_fails_for_missing_prefix_configuration(): void
     {
-        $this->git->ensureBranchInSync('upstream', '2.1')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.1')->shouldBeCalled();
 
         $this->expectExceptionObject(new \InvalidArgumentException(
             'Unable to split repository at prefix: No entry found for "[repositories][github.com][repos][hubkit-sandbox/empire][branches][2.x][split][pinchy]".'
@@ -335,7 +335,7 @@ final class BranchSplitshTest extends TestCase
     /** @test */
     public function dry_split_prefix_to_destinations_fails_for_disabled_prefix_configuration(): void
     {
-        $this->git->ensureBranchInSync('upstream', '6.1')->shouldBeCalled();
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '6.1')->shouldBeCalled();
 
         $this->expectExceptionObject(new \InvalidArgumentException(
             'Unable to split repository at prefix: Entry is disabled for "[repositories][github.com][repos][hubkit-sandbox/empire][branches][6.x][split][src/Module/WebhostingModule]".'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | Fix #57 
| License       | MIT

Add a repository specific (git-ignored) .hk_remotes file to use a different remote-name for the main repository (default "upstream"), and fork (default "origin").

**Note:** Your scripts might need to be updated if you allow this usage, use the `REMOTE_MAIN` to get the resolved remote-name (was "upstream").