### PR TITLE
Store pull-request metadata with git notes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,16 @@ parameters:
 			path: src/Cli/Handler/MergeHandler.php
 
 		-
+			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\MergeHandler\\:\\:addMetadata\\(\\) has parameter \\$authors with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Cli/Handler/MergeHandler.php
+
+		-
+			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\MergeHandler\\:\\:addMetadata\\(\\) has parameter \\$pr with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Cli/Handler/MergeHandler.php
+
+		-
 			message: "#^Method HubKit\\\\Cli\\\\Handler\\\\MergeHandler\\:\\:determineReviewStatus\\(\\) has parameter \\$pr with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Cli/Handler/MergeHandler.php
@@ -1062,6 +1072,16 @@ parameters:
 
 		-
 			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\MergeHandlerTest\\:\\:expectLocalBranchExists\\(\\) has parameter \\$removeRemote with no type specified\\.$#"
+			count: 1
+			path: tests/Handler/MergeHandlerTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\MergeHandlerTest\\:\\:expectMetadata\\(\\) has parameter \\$authors with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Handler/MergeHandlerTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\MergeHandlerTest\\:\\:expectMetadata\\(\\) has parameter \\$labels with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Handler/MergeHandlerTest.php
 

--- a/src/Cli/Handler/MergeHandler.php
+++ b/src/Cli/Handler/MergeHandler.php
@@ -78,7 +78,7 @@ final class MergeHandler extends GitBaseHandler
         $authors = [];
 
         $message = $this->getCommitMessage($pr, $authors, $branchLabel, $squash);
-        $title = $this->getCommitTitle($pr, $this->getCategory($pr, $args), $authors);
+        $title = $this->getCommitTitle($pr, $category = $this->getCategory($pr, $args), $authors);
 
         $mergeHash = $this->github->mergePullRequest($id, $title, $message, $pr['head']['sha'], $squash)['sha'];
 
@@ -88,6 +88,7 @@ final class MergeHandler extends GitBaseHandler
 
         $this->style->text('<fg=yellow>Pushing notes please wait...</>');
         $this->addCommentsToMergeCommit($pr, $mergeHash);
+        $this->addMetadata($mergeHash, $category, $pr, $authors);
 
         $this->style->success('Pull request has been merged.');
 
@@ -494,5 +495,35 @@ final class MergeHandler extends GitBaseHandler
         }
 
         return false;
+    }
+
+    private function addMetadata(string $sha, string $category, array $pr, array $authors): void
+    {
+        $labels = [];
+        $labelToMergeLabel = [
+            'deprecation' => 'deprecation',
+            'deprecation removal' => 'removed-deprecation',
+            'bc break' => 'bc-break',
+        ];
+
+        foreach ($pr['labels'] as $label) {
+            $labelName = mb_strtolower($label['name']);
+
+            if (isset($labelToMergeLabel[$labelName])) {
+                $labels[] = $labelToMergeLabel[$labelName];
+            }
+        }
+
+        $metadata = [
+            'schema' => 1,
+            'id' => $pr['number'],
+            'category' => $category,
+            'title' => $pr['title'],
+            'flags' => $labels,
+            'authors' => array_values($authors),
+        ];
+
+        $this->git->addNotes(json_encode($metadata, \JSON_THROW_ON_ERROR), $sha, 'pr-metadata');
+        $this->git->pushToRemote(REMOTE_MAIN, 'refs/notes/pr-metadata');
     }
 }

--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -308,6 +308,7 @@ class Git
             'notes',
             '--ref=' . $ref,
             'add',
+            '--no-stripspace',
             '-F',
             $tmpName,
             $commitHash,

--- a/tests/Handler/MergeHandlerTest.php
+++ b/tests/Handler/MergeHandlerTest.php
@@ -22,6 +22,7 @@ use HubKit\Service\Git;
 use HubKit\Service\GitHub;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument as PropArgument;
+use Prophecy\Argument\Token\TokenInterface;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
@@ -143,6 +144,7 @@ by who-else at 2014-11-23T14:50:24Z
 :+1:
 ');
 
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectLocalUpdate();
         $this->expectLocalBranchNotExists();
 
@@ -195,6 +197,7 @@ by who-else at 2014-11-23T14:50:24Z
             false
         )->willReturn(['sha' => self::MERGE_SHA]);
 
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectLocalUpdate();
         $this->expectLocalBranchNotExists();
 
@@ -286,6 +289,7 @@ by who-else at 2014-11-23T14:50:24Z
 :+1:
 ');
 
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectLocalUpdate(false);
         $this->expectLocalBranchNotExists();
 
@@ -331,6 +335,7 @@ by who-else at 2014-11-23T14:50:24Z
             false
         )->willReturn(['sha' => self::MERGE_SHA]);
 
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectNotes();
         $this->expectLocalUpdate(true, false);
         $this->expectLocalBranchNotExists();
@@ -376,6 +381,7 @@ by who-else at 2014-11-23T14:50:24Z
         )->willReturn(['sha' => self::MERGE_SHA]);
 
         $this->expectNotes();
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectLocalUpdate(false);
         $this->expectLocalBranchNotExists();
 
@@ -418,6 +424,7 @@ by who-else at 2014-11-23T14:50:24Z
         )->willReturn(['sha' => self::MERGE_SHA]);
 
         $this->expectNotes();
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectLocalUpdate();
         $this->expectLocalBranchNotExists();
 
@@ -459,6 +466,7 @@ by who-else at 2014-11-23T14:50:24Z
         )->willReturn(['sha' => self::MERGE_SHA]);
 
         $this->expectNotes();
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectLocalUpdate();
         $this->expectLocalBranchExists(false);
 
@@ -507,6 +515,7 @@ by who-else at 2014-11-23T14:50:24Z
         )->willReturn(['sha' => self::MERGE_SHA]);
 
         $this->expectNotes();
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectLocalUpdate();
         $this->expectLocalBranchExists();
 
@@ -555,6 +564,7 @@ by who-else at 2014-11-23T14:50:24Z
         )->willReturn(['sha' => self::MERGE_SHA]);
 
         $this->expectNotes();
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectLocalUpdate();
         $this->expectLocalBranchExists(true, false);
 
@@ -603,6 +613,7 @@ by who-else at 2014-11-23T14:50:24Z
         )->willReturn(['sha' => self::MERGE_SHA]);
 
         $this->expectNotes();
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectLocalUpdate();
         $this->expectLocalBranchExists(false, false);
 
@@ -658,6 +669,7 @@ by who-else at 2014-11-23T14:50:24Z
         )->willReturn(['sha' => self::MERGE_SHA]);
 
         $this->expectNotes();
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectLocalUpdate();
         $this->expectLocalBranchNotExists();
 
@@ -701,6 +713,7 @@ by who-else at 2014-11-23T14:50:24Z
         )->willReturn(['sha' => self::MERGE_SHA]);
 
         $this->expectNotes();
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectLocalUpdate();
         $this->expectLocalBranchNotExists();
 
@@ -759,6 +772,7 @@ by who-else at 2014-11-23T14:50:24Z
 :+1:
 ');
 
+        $this->expectMetadata('feature', $pr['title'], authors: ['doctor-wo', 'sstok']);
         $this->expectLocalUpdate();
         $this->expectLocalBranchNotExists();
 
@@ -819,6 +833,7 @@ by who-else at 2014-11-23T14:50:24Z
 :+1:
 ');
 
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectLocalUpdate();
         $this->expectLocalBranchNotExists();
 
@@ -861,6 +876,7 @@ by who-else at 2014-11-23T14:50:24Z
             false
         )->willReturn(['sha' => self::MERGE_SHA]);
 
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectNotes();
         $this->expectLocalUpdate();
         $this->expectLocalBranchNotExists();
@@ -920,6 +936,7 @@ by who-else at 2014-11-23T14:50:24Z
             false
         )->willReturn(['sha' => self::MERGE_SHA]);
 
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectNotes();
         $this->expectLocalUpdate();
         $this->expectLocalBranchNotExists();
@@ -981,6 +998,7 @@ by who-else at 2014-11-23T14:50:24Z
             false
         )->willReturn(['sha' => self::MERGE_SHA]);
 
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectNotes();
         $this->expectLocalUpdate();
         $this->expectLocalBranchNotExists();
@@ -1035,6 +1053,7 @@ by who-else at 2014-11-23T14:50:24Z
             false
         )->willReturn(['sha' => self::MERGE_SHA]);
 
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectNotes();
         $this->expectLocalUpdate();
         $this->expectLocalBranchNotExists();
@@ -1105,6 +1124,7 @@ by who-else at 2014-11-23T14:50:24Z
             false
         )->willReturn(['sha' => self::MERGE_SHA]);
 
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectNotes();
         $this->expectLocalUpdate();
         $this->expectLocalBranchNotExists();
@@ -1203,6 +1223,7 @@ by who-else at 2014-11-23T14:50:24Z
             true
         )->willReturn(['sha' => self::MERGE_SHA]);
 
+        $this->expectMetadata('feature', $pr['title'], labels: ['deprecation', 'bc-break']);
         $this->expectNotes();
         $this->expectLocalUpdate();
         $this->expectLocalBranchNotExists();
@@ -1316,6 +1337,7 @@ by who-else at 2014-11-23T14:50:24Z
             false
         )->willReturn(['sha' => self::MERGE_SHA]);
 
+        $this->expectMetadata('feature', $pr['title']);
         $this->expectNotes();
         $this->expectLocalUpdate();
         $this->expectLocalBranchNotExists();
@@ -1654,5 +1676,50 @@ by who-else at 2014-11-23T14:50:24Z
     private function expectNoSplits(): void
     {
         $this->branchSplitsh->splitBranch('master')->shouldNotBeCalled();
+    }
+
+    private function expectMetadata(string $category, string $title, array $labels = [], array $authors = ['sstok']): void
+    {
+        $this->git->addNotes(
+            new JsonValueToken([
+                'schema' => 1,
+                'id' => self::PR_NUMBER,
+                'category' => $category,
+                'title' => $title,
+                'flags' => $labels,
+                'authors' => $authors,
+            ]), self::MERGE_SHA, 'pr-metadata')->shouldBeCalled();
+        $this->git->pushToRemote(REMOTE_MAIN, 'refs/notes/pr-metadata')->shouldBeCalled();
+    }
+}
+
+class JsonValueToken implements TokenInterface
+{
+    /** @param array<string, mixed> $argument */
+    public function __construct(private array $argument) {}
+
+    public function scoreArgument(mixed $argument): bool | int
+    {
+        if (! \is_string($argument)) {
+            return false;
+        }
+
+        try {
+            $decoded = json_decode($argument, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return false;
+        }
+
+        return $decoded === $this->argument ? 8 : false;
+    }
+
+    public function isLast(): bool
+    {
+        return false;
+    }
+
+    public function __toString(): string
+    {
+        return json_encode($this->argument, \JSON_THROW_ON_ERROR);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

Currently the metadata for a pull-request (number, category, authors, special labels) is stored as part of the commit message.

In HuPKit v2.0 this will change completely to allow for customizing everything, including a custom templates, and custom categories (among many other things).

To make upgrading easier the storage of pr-metadata is now *also* stored with Git notes (ref: pr-metadata). The old (current) format and parsing is still used and will remain supported in v2.0 (using a configuration flag), and support for commit-message based parsing will be (eventually) removed in v3.0

