### PR TITLE
Prevent branch switching with GitFileReader

### DIFF
--- a/src/Service/Git/GitFileReader.php
+++ b/src/Service/Git/GitFileReader.php
@@ -78,7 +78,7 @@ class GitFileReader
             throw GitFileNotFound::atBranch($branch, $path);
         }
 
-        return $this->gitTempRepository->getLocal(mb_substr($this->gitBranch->getGitDirectory(), 0, -5), $branch) . \DIRECTORY_SEPARATOR . $path;
+        return $this->gitTempRepository->getLocal(mb_substr($this->gitBranch->getGitDirectory(), 0, -5), $branch, boundToBranch: true) . \DIRECTORY_SEPARATOR . $path;
     }
 
     /** @param string $path Path relative to repository root */
@@ -109,6 +109,6 @@ class GitFileReader
             throw GitFileNotFound::atRemote($remote, $branch, $path);
         }
 
-        return $this->gitTempRepository->getRemote($this->gitConfig->getLocal('remote.' . $remote . '.url'), $branch) . \DIRECTORY_SEPARATOR . $path;
+        return $this->gitTempRepository->getRemote($this->gitConfig->getLocal('remote.' . $remote . '.url'), $branch, boundToBranch: true) . \DIRECTORY_SEPARATOR . $path;
     }
 }

--- a/src/Service/Git/GitTempRepository.php
+++ b/src/Service/Git/GitTempRepository.php
@@ -28,14 +28,22 @@ class GitTempRepository
         private readonly Filesystem $filesystem
     ) {}
 
-    public function getLocal(string $directory, ?string $branch = null): string
+    /**
+     * @param bool $boundToBranch bind to the temp-location to $branch (to prevent switching during
+     *                            the process)
+     */
+    public function getLocal(string $directory, ?string $branch = null, bool $boundToBranch = false): string
     {
-        return $this->getRemote('file://' . $directory, $branch);
+        return $this->getRemote('file://' . $directory, $branch, $boundToBranch);
     }
 
-    public function getRemote(string $repositoryUrl, ?string $branch = null): string
+    /**
+     * @param bool $boundToBranch bind to the temp-location to $branch (to prevent switching during
+     *                            the process)
+     */
+    public function getRemote(string $repositoryUrl, ?string $branch = null, bool $boundToBranch = false): string
     {
-        $tempdir = $this->filesystem->storageTempDirectory('repo_' . sha1($repositoryUrl), false, $exists);
+        $tempdir = $this->filesystem->storageTempDirectory('repo_' . sha1($repositoryUrl . ($boundToBranch ? '~' . $branch : '')), false, $exists);
 
         if (! $exists) {
             $this->process->mustRun(['git', 'clone', '--no-checkout', '--origin', 'origin', $repositoryUrl, $tempdir]);

--- a/tests/Functional/Service/Git/GitTempRepositoryTest.php
+++ b/tests/Functional/Service/Git/GitTempRepositoryTest.php
@@ -95,6 +95,15 @@ final class GitTempRepositoryTest extends TestCase
     }
 
     /** @test */
+    public function it_creates_temporary_repository_for_specific_branch_without_switching(): void
+    {
+        $location = $this->gitTempRepository->getLocal($this->rootRepository, 'master');
+        $location2 = $this->gitTempRepository->getLocal($this->rootRepository, '_hubkit', true);
+
+        self::assertNotSame($location, $location2);
+    }
+
+    /** @test */
     public function it_updates_temporary_repository_for_specific_branch(): void
     {
         $location = $this->gitTempRepository->getLocal($this->rootRepository, 'master');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

The GitFileReader uses a temporary directory to clone to and read from, this clone is always singular to reduce too much temp directories.

But when using the GitFileReader it's possible this might cause some side-effects when one file reads from branch A but that file uses the GitFileReader to read from branch B, which would cause a switch (without switching back) and file A not being able to load any other files from branch A (as was expected).

Hopefully this will also fix a rather hard to find bug where configuration loading fails randomly.

