### PR TITLE
Storage temp-repository in separate location

### DIFF
--- a/docs/trouble-shooting.md
+++ b/docs/trouble-shooting.md
@@ -6,7 +6,7 @@ When HuPKit isn't working as expected.
 First make sure you are using the latest stable release, older versions
 are not covered by the backward compatibility policy.
 
-When you experience trouble with repository splitting, run the `cache-clear`
+When you experience trouble with repository splitting, run the `clear-cache`
 command.
 
 ## Self Diagnose
@@ -20,4 +20,4 @@ When you run into a local configuration error, and are not currently
 in the "_hubkit" configuration branch, run HuPKit with the env 
 `HUBKIT_NO_LOCAL=true` like `HUBKIT_NO_LOCAL=true hupkit edit-config`.
 
-And clear the cache using the `cache-clear` command.
+And clear the cache using the `clear-cache` command.

--- a/src/Cli/Handler/ClearCacheHandler.php
+++ b/src/Cli/Handler/ClearCacheHandler.php
@@ -44,7 +44,18 @@ final class ClearCacheHandler
                 ++$files;
             }
 
-            $this->style->comment(sprintf('Cache directory %s', $this->filesystem->getTempdir()));
+            /** @var \SplFileInfo $file */
+            foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->filesystem->getCacheDir(), \RecursiveDirectoryIterator::CURRENT_AS_FILEINFO | \RecursiveDirectoryIterator::SKIP_DOTS)) as $file) {
+                if (! $file->isFile()) {
+                    continue;
+                }
+
+                $size += $file->getSize() ?: 0;
+                ++$files;
+            }
+
+            $this->style->comment(sprintf('Temporary directory %s', $this->filesystem->getTempdir()));
+            $this->style->comment(sprintf('Cache directory %s', $this->filesystem->getCacheDir()));
             $this->style->comment(sprintf('Removed %s file taking-up %s of space', $files, Helper::formatMemory($size)));
         }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -72,7 +72,7 @@ class Container extends \Pimple\Container implements ContainerInterface
             $container['git'],
         );
 
-        $this['filesystem'] = static fn () => new Service\Filesystem();
+        $this['filesystem'] = static fn () => new Service\Filesystem(cacheDir: $_SERVER['HUBKIT_CACHE_DIR'] ?? null);
 
         $this['editor'] = static fn (self $container) => new Service\Editor($container['process'], $container['filesystem']);
 

--- a/src/Service/Filesystem.php
+++ b/src/Service/Filesystem.php
@@ -18,15 +18,23 @@ use Symfony\Component\Filesystem\Filesystem as SfFilesystem;
 class Filesystem
 {
     private readonly string $tempdir;
+    private readonly string $cacheDir;
     private readonly SfFilesystem $fs;
     private array $tempFilenames = [];
 
-    public function __construct(?string $tempdir = null, ?SfFilesystem $sfFilesystem = null)
+    public function __construct(?string $tempdir = null, ?string $cacheDir = null, ?SfFilesystem $sfFilesystem = null)
     {
         $this->fs = $sfFilesystem ?? new SfFilesystem();
+
         $this->tempdir = ($tempdir ?: sys_get_temp_dir()) . \DIRECTORY_SEPARATOR . 'hubkit';
+        $this->cacheDir = $cacheDir ?: ($_SERVER['HOME'] . \DIRECTORY_SEPARATOR . '.hubkit_cache');
+
+        if (! str_ends_with($this->cacheDir, '.hubkit_cache')) {
+            throw new \RuntimeException(sprintf('Cache directory is expected to end with ".hubkit_cache", got: %s', $this->cacheDir));
+        }
 
         $this->fs->mkdir($this->tempdir);
+        $this->fs->mkdir($this->cacheDir);
     }
 
     /**
@@ -123,11 +131,12 @@ class Filesystem
      */
     public function storageTempDirectory(string $name, bool $clearExisting = true, ?bool &$exists = null): string
     {
-        $tmpName = $this->tempdir . \DIRECTORY_SEPARATOR . 'stor' . \DIRECTORY_SEPARATOR . $name;
+        $tmpName = $this->cacheDir . \DIRECTORY_SEPARATOR . $name;
         $exists = $this->fs->exists($tmpName);
 
         if ($clearExisting && $exists) {
             $this->fs->remove($tmpName);
+            $exists = false;
         }
 
         $this->fs->mkdir($tmpName);
@@ -148,6 +157,7 @@ class Filesystem
     public function clearTempFolder(): void
     {
         $this->fs->remove($this->tempdir);
+        $this->fs->remove($this->cacheDir);
     }
 
     public function getFilesystem(): SfFilesystem
@@ -175,5 +185,10 @@ class Filesystem
     public function getTempdir(): string
     {
         return $this->tempdir;
+    }
+
+    public function getCacheDir(): string
+    {
+        return $this->cacheDir;
     }
 }

--- a/tests/Functional/Service/Git/GitFileReaderTest.php
+++ b/tests/Functional/Service/Git/GitFileReaderTest.php
@@ -73,9 +73,9 @@ final class GitFileReaderTest extends TestCase
 
         $this->cwd = $this->rootRepository;
 
-        $this->filesystem ??= new Filesystem();
+        $this->filesystem ??= new Filesystem(cacheDir: sys_get_temp_dir() . '/hubkit_gfs_test/.hubkit_cache');
         $this->cliProcess = $this->getProcessService($this->rootRepository);
-        $this->cliProcess->ignoreCwdChangeWhen(static fn (string $val): bool => str_contains($val, '/hubkit/stor/repo_'));
+        $this->cliProcess->ignoreCwdChangeWhen(static fn (string $val): bool => str_contains($val, '/hubkit_gfs_test/.hubkit_cache/repo_'));
 
         $this->gitTempRepository ??= new GitTempRepository($this->cliProcess, $this->filesystem);
     }

--- a/tests/Functional/Service/Git/GitTempRepositoryTest.php
+++ b/tests/Functional/Service/Git/GitTempRepositoryTest.php
@@ -48,9 +48,9 @@ final class GitTempRepositoryTest extends TestCase
 
         $this->cwd = $this->rootRepository;
 
-        $this->filesystem ??= new Filesystem($tempDir);
+        $this->filesystem ??= new Filesystem($tempDir, cacheDir: sys_get_temp_dir() . '/hubkit_gfs_test/.hubkit_cache');
         $this->cliProcess = $this->getProcessService($this->rootRepository);
-        $this->cliProcess->ignoreCwdChangeWhen(static fn (string $val): bool => str_contains($val, '/hubkit/stor/repo_'));
+        $this->cliProcess->ignoreCwdChangeWhen(static fn (string $val): bool => str_contains($val, '/hubkit_gfs_test/.hubkit_cache/repo_'));
 
         $this->gitTempRepository ??= new GitTempRepository($this->cliProcess, $this->filesystem);
     }

--- a/tests/Functional/Service/Git/SplitshGitTest.php
+++ b/tests/Functional/Service/Git/SplitshGitTest.php
@@ -67,7 +67,7 @@ final class SplitshGitTest extends TestCase
         $this->createGitDirectory($tempDir . '/split-validator');
         $this->createGitDirectory($tempDir . '/split-doctrine');
 
-        $this->filesystem = new Filesystem($tempDir);
+        $this->filesystem = new Filesystem($tempDir, $tempDir . '/.hubkit_cache');
         $this->cliProcess = $this->getProcessService($this->rootRepository);
         $this->cliProcess->ignoreCwdChangeWhen(static fn (string $val): bool => true);
 

--- a/tests/Unit/Service/FilesystemTest.php
+++ b/tests/Unit/Service/FilesystemTest.php
@@ -34,18 +34,20 @@ final class FilesystemTest extends TestCase
     public const MOCK_TMP_DIR = '{:temp:}';
 
     private ?string $tempDir = null;
+    private ?string $cacheDir = null;
 
     /** @before */
     public function setUpTempDirectoryPath(): void
     {
         $this->tempDir = realpath(sys_get_temp_dir()) . '/hbk-fs/' . mb_substr(hash('sha256', random_bytes(8)), 0, 10);
+        $this->cacheDir = realpath(sys_get_temp_dir()) . '/hbk-cfs/' . mb_substr(hash('sha256', random_bytes(8)), 0, 10) . '/.hubkit_cache';
         self::assertDirectoryDoesNotExist($this->tempDir); // Pre-condition
     }
 
     /** @test */
     public function it_creates_a_temp_file_with_no_contents(): void
     {
-        $filesystem = new Filesystem($this->tempDir);
+        $filesystem = new Filesystem($this->tempDir, $this->cacheDir);
 
         $filename = $filesystem->newTempFilename();
 
@@ -59,7 +61,7 @@ final class FilesystemTest extends TestCase
     /** @test */
     public function it_creates_a_temp_file_with_contents(): void
     {
-        $filesystem = new Filesystem($this->tempDir);
+        $filesystem = new Filesystem($this->tempDir, $this->cacheDir);
 
         $filename = $filesystem->newTempFilename('Test, test. I am Testing my tests for you');
 
@@ -77,11 +79,12 @@ final class FilesystemTest extends TestCase
 
         $sfFilesystem = $this->prophesize(SfFilesystem::class);
         $sfFilesystem->mkdir('{:temp:}/hubkit')->shouldBeCalledOnce();
+        $sfFilesystem->mkdir('{:temp:}/.hubkit_cache')->shouldBeCalledOnce();
         $sfFilesystem->exists($path)->willReturn(false);
         $sfFilesystem->remove(Argument::any())->shouldNotBeCalled();
         $sfFilesystem->mkdir($path)->shouldBeCalledOnce();
 
-        $filesystem = new Filesystem(self::MOCK_TMP_DIR, $sfFilesystem->reveal());
+        $filesystem = new Filesystem(self::MOCK_TMP_DIR, self::MOCK_TMP_DIR . '/.hubkit_cache', $sfFilesystem->reveal());
 
         self::assertEquals($path, $filesystem->tempDirectory('split'));
     }
@@ -98,11 +101,12 @@ final class FilesystemTest extends TestCase
 
         $sfFilesystem = $this->prophesize(SfFilesystem::class);
         $sfFilesystem->mkdir('{:temp:}/hubkit')->shouldBeCalledOnce();
+        $sfFilesystem->mkdir('{:temp:}/.hubkit_cache')->shouldBeCalledOnce();
         $sfFilesystem->exists($path)->willReturn(true);
         $sfFilesystem->remove($path)->shouldBeCalledOnce();
         $sfFilesystem->mkdir($path)->shouldBeCalledOnce();
 
-        $filesystem = new Filesystem(self::MOCK_TMP_DIR, $sfFilesystem->reveal());
+        $filesystem = new Filesystem(self::MOCK_TMP_DIR, self::MOCK_TMP_DIR . '/.hubkit_cache', $sfFilesystem->reveal());
 
         self::assertEquals($path, $filesystem->tempDirectory('split'));
     }
@@ -132,7 +136,7 @@ final class FilesystemTest extends TestCase
                 }
             )
         )->shouldBeCalledOnce();
-        $filesystem = new Filesystem($this->tempDir, $sfFilesystem->reveal());
+        $filesystem = new Filesystem($this->tempDir, $this->cacheDir, $sfFilesystem->reveal());
 
         $filesystem->tempDirectory('split1');
         $filesystem->tempDirectory('split2');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

Using the systems temporary directory leads to random Git repository corruptions (in my case).

Instead the cache is now stored in `$HOME/.hubkit_cache`, and can be alternatively changed using the new `HUBKIT_CACHE_DIR` environment variable (expects the value ends with `.hubkit_cache` as clearing the cache removes 'this' directory, so any wrong configuration should not delete your entire system 😄 ).