### PR TITLE
Deprecate global repositories configuration

### DIFF
--- a/docs/config-v1.md
+++ b/docs/config-v1.md
@@ -1,12 +1,12 @@
 Configuration
 =============
 
-> [!NOTE]
-> Since HuPKit v1.4 using global configuration for repositories is deprecated,
-> the examples in this chapter use schema_version 2 which requires at least HuPKit v1.2.**
+**The examples in this chapter assume schema_version 2 is used, schema_version 1 is still supported. 
+But schema_version 2 uses some advanced features that could cause problems when not
+all team members use the same configuration!** See [upgrade](upgrade.md) for more information.
 
-See [Configuration Schema 1](config-v1.md) for versions prior.
-See [upgrade instructions](upgrade.md) to update your configuration.
+Since HuPKit v1.2 it's possible to use a local configuration housed in the repository itself,
+see below for more information.
 
 Schema Version
 --------------
@@ -16,7 +16,10 @@ The `schema_version` defines configuration schema version.
 Since HuPKit v1.2 `schema_version` 2 should be used with the correct structure.
 
 While `schema_version` 1 is still supported until HuPKit 2.0, it will
-produce multiple warning messages everytime HuPKit is used.
+produce a warning message everytime HuPKit is used.
+
+The new configuration schema provides for some powerful features including
+a local configuration file and per branch configuration.
 
 Authentication
 --------------
@@ -52,7 +55,14 @@ Repository Configuration
 ------------------------
 
 Specific features like repository splitting or disabling upmerge for some branches
-only work when the configuration for a repository is set-up.
+only work when the configuration for these repositories is set.
+
+You can either a use local configuration (recommended) or store the configuration
+in the main `config.php` file which also contains your credentials.
+
+### Local Configuration
+
+Since HuPKit v1.2 it's possible to use a local configuration housed in the repository itself.
 
 The configuration (and hook-scripts) are kept in a 'orphaned' branch "_hubkit"
 (please notice the hu**b** not hu**p**!).
@@ -61,10 +71,10 @@ _An orphan branch has no relation to any other branch, it's fully separate,
 and thus no common parent. This same technique is also used by GitHub for
 pages stored separate from the main branch._
 
-> [!CAUTION]
-> **No authentication credentials must be stored in local configuration!**
+**No authentication credentials must be stored in local configuration!**
 
-This file contains the configuration _only_ for the current repository.
+This file contains the configuration _only_ for the current repository and supersedes
+the repository configuration entry in the main `config.php` for _this_ repository.
 
 ```php
 <?php
@@ -74,9 +84,9 @@ return [
     'schema_version' => 2,
 
     // Adapter configuration (optional, when cannot be resolved automatically)
-    // 'adapter' => 'github', //Defaults to github, currently no other adapters supported
-    // 'host' => 'github.com',
-    // 'repository' => 'organization/repository-name',
+    'adapter' => 'github', //Defaults to github, currently no other adapters supported
+    'host' => 'github.com',
+    'repository' => 'organization/repository-name',
 
     // Since v1.3 - which branch is considered the main branch. Either: 'main', 'master', '2.0', or 'trunk'
     // This configuration is used (among) for upmerging as know the last branch in the list.
@@ -88,7 +98,7 @@ return [
     // See branches section below for supported configuration
     'branches' => [],
 
-    // Branches-alias for 'named' branches
+    // Branches-alias for 'unstable' branches
     //
     // This only applies to branches that are not explicitly versioned (like 1.0, 1.5)
     // The value should be a stable major.minor version (not: 0.5, master, 1.5-dev, 1.2-beta1) but 1.0, 1.5, 23.4
@@ -100,7 +110,7 @@ return [
 ];
 ````
 
-### Initialize Configuration
+#### Initialize Configuration
 
 To create the special branch that HuPKit uses to store the config.php file and some
 additional scripts for special operations, run the `init-config` command.
@@ -109,9 +119,8 @@ The command will automatically import any existing configuration for the reposit
 from the main `config.php`, and all files stored in the ".hubkit" directory
 (of the current branch).
 
-> [!NOTE]
-> The .gitignore is automatically copied from your current branch to ensure
-> no unrelated files are accidentally added when working on this branch.
+**Note:** The .gitignore is automatically copied from your current branch to ensure
+no unrelated files are accidentally added when working on this branch.
 
 The _hubkit branch sits separate from your normal Git workflow and shares
 no parenting to any existing branch.
@@ -121,14 +130,65 @@ Once you are done run the `sync-config` command to push your changes.
 Use the `self-diagnose` command to check your configuration and see if any
 updated is needed.
 
+#### Editing
+
+To change the contents of the _hubkit branch run the `edit-config` command.
+
+**Note:** If this fails due to a configuration error run HuPKit with the
+env `HUBKIT_NO_LOCAL=true` like `HUBKIT_NO_LOCAL=true hupkit self-diagnose`.
+
+### Synchronize Configuration
+
+To update the configuration by either pushing your changes or pulling-in
+the latest version from "upstream" simply run the `sync-config` command.
+
+Only if your branches have diverged to much you need to resolve any
+conflicts manually. Once done run the command again.
+
+### Configuration in the main config.php
+
+The repository configuration structure starts with the hostname as the root, followed
+by a list of repositories housed at the hub (like github.com) with their full-name
+'organization/repository-name' like `rollerworks/search`.
+
+```php
+<?php
+// config.php
+
+return [
+    'schema_version' => 2,
+    'github' => [
+        'github.com' => [ // hostname of the hub
+            'username' => '', // fill-in your github username
+            'api_token' => '', // fill-in the new GitHub authentication token (NOT YOUR PASSWORD!)
+        ],
+//        'hub.my-corp.com' => [ // hostname of your GitHub Enterprise installation
+//            'username' => '', // fill-in your github username
+//            'api_token' => '', // fill-in the new GitHub authentication token (NOT YOUR PASSWORD!)
+//            'api_url' => 'https://api.hub.mycorp.com/' // schema + hostname to API endpoint (excluding API version)
+//        ],
+    ],
+
+    'repositories' => [
+        'github.com' => [
+            'organization/repository-name' => [
+                'branches' => [] // See branches section below for supported configuration
+            ],
+        ],
+    ],
+];
+````
+
 ### Branches
+
+Each repository has a 'branches' configuration to either set the configuration
+for all branches using `:default`, or per specific branch `2.0`.
 
 A branch name can be either `:default` (see below), any valid branch-name,
 a minor-version pattern `2.x`/`v2.*`, or a regexp (without anchors or options)
 like `/[1-2]\.\d+/`.
 
-> [!NOTE]
-> When an actual branch is named like a pattern (`1.x`) use `#1.x` instead.
+**Note:** When an actual branch is named like a pattern (`1.x`) use `#1.x` instead.
 
 The `:default` branch defines the default configuration for _all_ branches, and
 is later merged with the configuration of a specific branch. Use `'ignore-default' => true`
@@ -144,10 +204,9 @@ Use `false` to mark a branch as unmaintained and skip upmerging to *and*
 from this branch, this will give a warning whenever this branch is used
 for either merging, releasing, taking an issue, etc.
 
-> [!TIP]
-> Use regexes like `/[12]\.\d+/` or `/main|dev/trunk|(12\.0)/` to use multiple
-> versions or names at once (no anchors or head grouping, `/main|master/` not
-> `/(main|12\.0)/`).
+**Tip:** Use regexes like `/[12]\.\d+/` or `/main|dev/trunk|(12\.0)/` to use multiple 
+versions or names at once (no anchors or head grouping, `/main|master/` not 
+`/(main|12\.0)/`).
 
 Each branch has the following options:
 
@@ -160,55 +219,49 @@ Each branch has the following options:
 | `maintained`     | Boolean | `true`    | `true` when maintained, use `false` as config value shorthand.                                                   |
 
 ```php
-// config.php
+// ... At config path `repositories.[github.com].[organization/repository-name]`
+// for the main config.php, and at the root for local configuration.
 
-return [
-
-    // ...
-
-    'branches' => [
-        ':default' => [
-            'sync-tags' => true,
-            'split' => [
-                // A path (relative to root, no patterns) and the url to split to (with additional options)
-                // See below for all options.
-                'src/Module/CoreModule' => 'git@github.com:hubkit-sandbox/core-module.git',
-                'src/Module/WebhostingModule' => 'git@github.com:hubkit-sandbox/webhosting-module.git',
-                'docs' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => false],
-            ],
-        ],
-        'main' => [ // Can be any valid branch-name: dev/trunk, master, development
-            'src/Module/CustomerModule' => 'git@github.com:hubkit-sandbox/customer-module.git',
-        ],
-        '1.0' => false, // Mark branch as unmaintained
-        '2.x' => [ // '2.x' is a pattern equivalent to '/2\.\d+/'
-            'upmerge' => false, // Disable upmerge for this branch, effectively all of the '2.x' range are skipped
-            // Split's is inherited and merged from ':default'
-            'split' => [
-                'src/Module/DomainRegModule' => 'git@github.com:hubkit-sandbox/webhosting-module.git',
-            ],
-        ],
-        '#3.x' => [ // The actual branch name is 3.x would be confused for a pattern
-            'sync-tags' => null, // Inherit from the root configuration.
-            'split' => [
-                'src/Module/WebhostingModule' => false,
-                'src/Module/DomainRegModule' => 'git@github.com:hubkit-sandbox/webhosting-module.git',
-            ],
-        ],
-        '/4\.\d+/' => [ // Same as 4.x
-            'ignore-default' => true, // Nothing is inherited from ':default'
-            'sync-tags' => false,
-            'src/Bundle/CoreBundle' => 'git@github.com:hubkit-sandbox/core-module.git',
-            'src/Bundle/WebhostingBundle' => 'git@github.com:hubkit-sandbox/webhosting-module.git',
+'branches' => [
+    ':default' => [
+        'sync-tags' => true,
+        'split' => [
+            // A path (relative to root, no patterns) and the url to split to (with additional options)
+            // See below for all options.
+            'src/Module/CoreModule' => 'git@github.com:hubkit-sandbox/core-module.git',
+            'src/Module/WebhostingModule' => 'git@github.com:hubkit-sandbox/webhosting-module.git',
             'docs' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => false],
         ],
     ],
-
-];
+    'main' => [ // Can be any valid branch-name: dev/trunk, master, development
+        'src/Module/CustomerModule' => 'git@github.com:hubkit-sandbox/customer-module.git',
+    ],   
+    '1.0' => false, // Mark branch as unmaintained
+    '2.x' => [ // '2.x' is a pattern equivalent to '/2\.\d+/'
+        'upmerge' => false, // Disable upmerge for this branch, effectively all of the '2.x' range are skipped
+        // Split's is inherited and merged from ':default'
+        'split' => [
+            'src/Module/DomainRegModule' => 'git@github.com:hubkit-sandbox/webhosting-module.git',
+        ],
+    ],
+    '#3.x' => [ // The actual branch name is 3.x would be confused for a pattern
+        'sync-tags' => null, // Inherit from the root configuration.
+        'split' => [
+            'src/Module/WebhostingModule' => false,
+            'src/Module/DomainRegModule' => 'git@github.com:hubkit-sandbox/webhosting-module.git',
+        ],
+    ],
+    '/4\.\d+/' => [ // Same as 4.x
+        'ignore-default' => true, // Nothing is inherited from ':default'
+        'sync-tags' => false,
+        'src/Bundle/CoreBundle' => 'git@github.com:hubkit-sandbox/core-module.git',
+        'src/Bundle/WebhostingBundle' => 'git@github.com:hubkit-sandbox/webhosting-module.git',
+        'docs' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => false],
+    ],
+],
 ```
 
-> [!NOTE]
-> A branch cannot start with Git refs `(heads, tags, remotes, notes)/`, or be `HEAD`.
+**Note:** A branch cannot start with Git refs `(heads, tags, remotes, notes)/`, or be `HEAD`.
 
 #### Repository splitting (`split` config)
 <a name="splitting"></a>
@@ -217,46 +270,20 @@ A list of paths (relative to repository root, *no patterns*) and the value,
 either a 'push url' or an array with following options
 `['url' => 'push url', 'sync-tags' => false]`.
 
-> [!IMPORTANT]
-> Splits are expected to exist, see also [Managing Split Repositories](split-repositories.md).
+**Note:** Splits are expected to exist, see also [Managing Split Repositories](split-repositories.md).
 
 ```php
-return [
-    // ...
+// ... At config path `repositories.[github.com].[organization/repository-name].[branch-name]`
 
-    'branches' => [
-        ':default' => [
-            // ...
-        
-            'split' => [
-                'src/Module/CoreModule' => 'git@github.com:hubkit-sandbox/core-module.git',
-                'src/Module/WebhostingModule' => 'git@github.com:hubkit-sandbox/webhosting-module.git',
-                'docs' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => false],
-            ],
-       ],
-    ],
+'split' => [
+    'src/Module/CoreModule' => 'git@github.com:hubkit-sandbox/core-module.git',
+    'src/Module/WebhostingModule' => 'git@github.com:hubkit-sandbox/webhosting-module.git',
+    'docs' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => false],
 ],
 ```
 
-> [!NOTE]
-> Missing directories are ignored with a warning. In HuPKit v2.0 this behavior is bound to change,
-> use the branches configuration to ensure to paths aren't missing.
-
-### Editing
-
-To change the contents of the _hubkit branch run the `edit-config` command.
-
-> [!NOTE]
-> If this fails due to a configuration error run HuPKit with the
-> env `HUBKIT_NO_LOCAL=true` like `HUBKIT_NO_LOCAL=true hupkit self-diagnose`.
-
-### Synchronize Configuration
-
-To update the configuration by either pushing your changes or pulling-in
-the latest version from "upstream" simply run the `sync-config` command.
-
-Only if your branches have diverged to much you need to resolve any
-conflicts manually. Once done run the command again.
+**Note:** Missing directories are ignored with a warning. In HuPKit v2.0 this behavior is bound to change,
+use the branches configuration to ensure to paths aren't missing.
 
 Remote names
 ------------
@@ -278,16 +305,14 @@ fork = origin
 The config "main" is the main repository which all team-members pull and push from,
 "fork" is your own fork (if any).
 
-> [!NOTE]
-> This is about remote _names_ not actual repository url's.
+**Note:** This is about remote _names_ not actual repository url's.
 
-The file format is similar to an ini-file, a line can contain either a comment (`; Commment`)
+The file format is similar to an ini-file, a line can contain either a comment (`; Commment`) 
 _or_ a variable ("main" or "fork"), no overwrites, no different names (than shown), 
 and comments can only be used on their own line (not at the end of a variable declaration).
 
-> [!IMPORTANT]
-> This file should be ignored by Git as it only applies to your own local
-> `.git/config` file.
+**Caution:** This file should be ignored by Git as it only applies to your own local
+`.git/config` file.
 
 Use the `-v` flag with any command to see which value is used.
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,6 +1,15 @@
 Upgrade HuPKit
 ==============
 
+Upgrade to v1.4.0-BETA1
+-----------------------
+
+Using global configuration for repositories is now deprecated and will be removed
+in v2.0. Use repository local configuration instead.
+
+Use the `init-config` command for each repository to import the global configuration,
+then manually remove the repository in the global configuration.
+
 Upgrade to v1.3.0-BETA2
 -----------------------
 

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -26,6 +26,7 @@ final class ConfigFactory
     private string $currentDir;
     private string $configFile;
     private ?string $localConfigFile = null;
+    private bool $detectedGlobalRepositories = false;
 
     public function __construct(
         string $currentDir,
@@ -90,8 +91,17 @@ final class ConfigFactory
             // So store it here, there is no expectation to explicitly get this for a repository.
             //
             // In the future the whole concept for using 'global' configuration for a repository
-            // might be dropped in favor of local-only configuration.
+            // is removed in favor of local-only configuration.
             $config['_main_branch'] = $this->findMainBranch();
+        }
+
+        if ($this->detectedGlobalRepositories) {
+            $this->style->caution(
+                <<<MSG
+                    Setting repositories in global configuration is deprecated since HuPKit v1.4 and will be removed in v2.0.
+                    Use local repository configurations instead.
+                    MSG
+            );
         }
 
         $config['current_dir'] = $this->currentDir;
@@ -163,6 +173,14 @@ final class ConfigFactory
 
                     $v['repositories'] = $repositories;
                     unset($v['repos']);
+
+                    return $v;
+                })
+            ->end()
+            ->validate()
+                ->ifTrue(static fn ($v): bool => \count($v['repositories']) > 0)
+                ->then(function (array $v): array {
+                    $this->detectedGlobalRepositories = true;
 
                     return $v;
                 })

--- a/tests/ConfigFactoryTest.php
+++ b/tests/ConfigFactoryTest.php
@@ -615,7 +615,10 @@ final class ConfigFactoryTest extends TestCase
         );
         self::assertEquals('trunk', $resolved->getMainBranch());
 
-        $this->assertNoOutput();
+        $this->assertOutputMatches([
+            'Setting repositories in global configuration is deprecated since HuPKit v1.4 and will be removed in v2.0.',
+            'Use local repository configurations instead.',
+        ]);
     }
 
     private function getGitFileReaderWithExistentFile(string $fileLocation): GitFileReader

--- a/tests/Functional/Service/Git/GitBranchTest.php
+++ b/tests/Functional/Service/Git/GitBranchTest.php
@@ -199,7 +199,7 @@ final class GitBranchTest extends TestCase
         $this->runCliCommand(['git', 'checkout', 'master']);
 
         $this->expectException(ProcessFailedException::class);
-        $this->expectExceptionMessageMatches("/error: The branch '2\\.0' is not fully merged\\./i");
+        $this->expectExceptionMessageMatches("/error: The branch '2\\.0' is not fully merged\\.?/i");
 
         $this->git->deleteBranch('2.0');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tickets       | Fix #140 
| License       | MIT

Repository configuration (not credentials) must be stored in the local configuration in v2.0.

The reason for this change is simple: When you work in a team (or on multiple systems) all team-members/systems should use the same configuration. Configuration should be kept as close the actual repository as possible, storing this locally is not recommended.

And another more technical reason is that the global configuration only works when the adapter and host are resolved, which means it's not possible (atm) to load the configuration for a repository prior to initialization and causes some technical challenges (like the main-branch resolving).

As v2.0 will also support Extensions (plug-ins) keeping the configuration globally would be impossible.