### PR TITLE
Allow to split/release for changed prefixes only

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -97,6 +97,15 @@ return [
     //     // 'dev/main' => '1.0',
     //     // '1.x' => '1.5',
     // ],
+    
+    // Since v1.4
+    //'pull_request' => [
+           // Either:
+           //  * 'all' (default)
+           //  * 'changed-only' (only split changed files matched in prefixes)
+           //  * 'none' (don't split, some as the `--no-split option` for the `merge` command)
+    //    'split' => 'all',
+    //],
 ];
 ````
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -97,13 +97,21 @@ return [
     //     // 'dev/main' => '1.0',
     //     // '1.x' => '1.5',
     // ],
-    
+
     // Since v1.4
     //'pull_request' => [
            // Either:
            //  * 'all' (default)
            //  * 'changed-only' (only split changed files matched in prefixes)
            //  * 'none' (don't split, some as the `--no-split option` for the `merge` command)
+    //    'split' => 'all',
+    //],
+
+    // Since v1.4
+    //'release' => [         
+          // Either:
+          // 'all' (default)
+          // 'changed-only' (only create split releases for prefixes that have changed since the last release)
     //    'split' => 'all',
     //],
 ];
@@ -236,7 +244,7 @@ return [
     'branches' => [
         ':default' => [
             // ...
-        
+
             'split' => [
                 'src/Module/CoreModule' => 'git@github.com:hubkit-sandbox/core-module.git',
                 'src/Module/WebhostingModule' => 'git@github.com:hubkit-sandbox/webhosting-module.git',
@@ -291,7 +299,7 @@ The config "main" is the main repository which all team-members pull and push fr
 > This is about remote _names_ not actual repository url's.
 
 The file format is similar to an ini-file, a line can contain either a comment (`; Commment`)
-_or_ a variable ("main" or "fork"), no overwrites, no different names (than shown), 
+_or_ a variable ("main" or "fork"), no overwrites, no different names (than shown),
 and comments can only be used on their own line (not at the end of a variable declaration).
 
 > [!IMPORTANT]

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -306,6 +306,11 @@ parameters:
 			path: src/Service/GitHub.php
 
 		-
+			message: "#^Method HubKit\\\\Service\\\\GitHub\\:\\:getPullRequestFiles\\(\\) return type has no value type specified in iterable type iterable\\.$#"
+			count: 1
+			path: src/Service/GitHub.php
+
+		-
 			message: "#^Method HubKit\\\\Service\\\\GitHub\\:\\:getPullRequestReviews\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Service/GitHub.php
@@ -1087,6 +1092,11 @@ parameters:
 
 		-
 			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\MergeHandlerTest\\:\\:expectNotes\\(\\) has parameter \\$notes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Handler/MergeHandlerTest.php
+
+		-
+			message: "#^Method HubKit\\\\Tests\\\\Handler\\\\MergeHandlerTest\\:\\:expectPrInfo\\(\\) has parameter \\$fileNames with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Handler/MergeHandlerTest.php
 

--- a/src/Cli/Handler/MergeHandler.php
+++ b/src/Cli/Handler/MergeHandler.php
@@ -93,7 +93,7 @@ final class MergeHandler extends GitBaseHandler
         $this->style->success('Pull request has been merged.');
 
         if (! $args->getOption('no-pull') && $this->updateLocalBranch($pr['base']['ref']) && ! $args->getOption('no-split')) {
-            $this->branchSplitsh->splitBranch($pr['base']['ref']);
+            $this->handleSplitOperation($pr['base']['ref'], $pr['number']);
         }
 
         if (! $args->getOption('squash') && ! $args->getOption('no-cleanup')) {
@@ -525,5 +525,54 @@ final class MergeHandler extends GitBaseHandler
 
         $this->git->addNotes(json_encode($metadata, \JSON_THROW_ON_ERROR), $sha, 'pr-metadata');
         $this->git->pushToRemote(REMOTE_MAIN, 'refs/notes/pr-metadata');
+    }
+
+    private function handleSplitOperation(string $ref, int $number): void
+    {
+        $split = $this->config->getPullRequestConfig()['split'];
+
+        if ($split === 'none') {
+            return;
+        }
+
+        if ($split === 'all') {
+            $this->branchSplitsh->splitBranch($ref);
+
+            return;
+        }
+
+        $changedFiles = [];
+        $i = 0;
+
+        // Changes only.
+        //
+        // Each page contains 30 items, we limit the total of pages to 10.
+        // 200 file changes for a PR is average (excluding CS fixes).
+        //
+        // GitHub limits total of files to 3000;
+        // 3000 equals around a 100 API calls, and might hit the rate-limit.
+        foreach ($this->github->getPullRequestFiles($number) as $file) {
+            $changedFiles[] = $file['filename'];
+
+            if ($i > 300) {
+                break;
+            }
+
+            ++$i;
+        }
+
+        if ($i > 300) {
+            $this->style->warning('More than 300 files have been changed. Cannot perform a changed-only split.');
+
+            if (! $this->style->confirm('Do you want to continue with a complete split instead?')) {
+                $this->style->note('Split was skipped.');
+
+                return;
+            }
+
+            $changedFiles = [];
+        }
+
+        $this->branchSplitsh->splitBranch($ref, $changedFiles);
     }
 }

--- a/src/Cli/Handler/ReleaseHandler.php
+++ b/src/Cli/Handler/ReleaseHandler.php
@@ -85,7 +85,7 @@ final class ReleaseHandler extends GitBaseHandler
 
         // Perform the sub-split and tagging first as it's easier to recover from split error
         // then being able to re-run the release command on the source repository.
-        $this->branchSplitsh->syncTags($branch, $versionStr);
+        $this->handleSplitReleases($branch, $versionStr, $args->getOption('force-split-all'));
 
         $this->process->mustRun(['git', 'tag', '-s', 'v' . $versionStr, '-m', 'Release ' . $versionStr]);
         $this->process->mustRun(['git', 'push', REMOTE_MAIN, 'v' . $versionStr]);
@@ -206,5 +206,22 @@ final class ReleaseHandler extends GitBaseHandler
                 implode(', v', $suggested)
             )
         );
+    }
+
+    private function handleSplitReleases(string $branch, string $versionStr, bool $forceAll): void
+    {
+        if ($this->config->getReleaseConfig()['split'] === 'all' || $forceAll) {
+            $this->branchSplitsh->syncTags($branch, $versionStr);
+
+            return;
+        }
+
+        $previousRelease = $this->git->getLastTagOnBranch($branch, true);
+
+        if ($previousRelease) {
+            $this->style->block(\sprintf('Creating split-releases <options=underscore>only for changes</> since "%s".', $previousRelease), 'INFO', 'fg=green', ' ', false, false);
+        }
+
+        $this->branchSplitsh->syncTags($branch, $versionStr, $previousRelease);
     }
 }

--- a/src/Cli/HubKitApplicationConfig.php
+++ b/src/Cli/HubKitApplicationConfig.php
@@ -352,6 +352,7 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
             ->addOption('no-edit', null, Option::NO_VALUE | Option::BOOLEAN, 'Don\'t open the editor for editing the release page')
             ->addOption('title', null, Option::REQUIRED_VALUE | Option::NULLABLE | Option::STRING, 'Custom title for the release (added after version)')
             ->addOption('pre-release', null, Option::NO_VALUE | Option::BOOLEAN, 'Mark as pre-release (not production ready)')
+            ->addOption('force-split-all', null, Option::NO_VALUE | Option::BOOLEAN, 'Force splitting of all, overwriting the "release.split" configuration')
             ->setHandler(function () {
                 return new Handler\ReleaseHandler(
                     $this->container['style'],

--- a/src/Config.php
+++ b/src/Config.php
@@ -227,6 +227,12 @@ final class Config
         return $this->get(['_local', 'pull_request'], ['split' => 'all']);
     }
 
+    /** @return array{split: string} */
+    public function getReleaseConfig(): array
+    {
+        return $this->get(['_local', 'release'], ['split' => 'all']);
+    }
+
     /**
      * @param array<string, mixed> $default
      * @param array<string, mixed> $config

--- a/src/Config.php
+++ b/src/Config.php
@@ -221,6 +221,12 @@ final class Config
         return $this->getFirstNotNull([['_local', 'main_branch'], ['_main_branch']], 'main');
     }
 
+    /** @return array{split: string} */
+    public function getPullRequestConfig(): array
+    {
+        return $this->get(['_local', 'pull_request'], ['split' => 'all']);
+    }
+
     /**
      * @param array<string, mixed> $default
      * @param array<string, mixed> $config

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -279,7 +279,7 @@ final class ConfigFactory
                         ->arrayPrototype()
                             ->normalizeKeys(false)
                             ->beforeNormalization()
-                                ->ifTrue(static fn ($v): bool => is_string($v) || $v === false)
+                                ->ifTrue(static fn ($v): bool => \is_string($v) || $v === false)
                                 ->then(static fn ($v): array => ['url' => $v])
                             ->end()
                             ->children()

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -406,6 +406,15 @@ final class ConfigFactory
                         ->always(fn ($v) => $v === null ? $this->findMainBranch() : self::validateBranchName((string) $v))
                     ->end()
                 ->end()
+                ->arrayNode('pull_request')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->enumNode('split')
+                            ->values(['all', 'changed-only', 'none'])
+                            ->defaultValue('all')
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -415,6 +415,15 @@ final class ConfigFactory
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('release')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->enumNode('split')
+                            ->values(['all', 'changed-only'])
+                            ->defaultValue('all')
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/src/Service/BranchSplitsh.php
+++ b/src/Service/BranchSplitsh.php
@@ -171,9 +171,13 @@ class BranchSplitsh
      *
      * @return int The number of tags synchronized
      */
-    public function syncTags(string $branch, string $versionStr): int
+    public function syncTags(string $branch, string $versionStr, ?string $onlyChangesSince = null): int
     {
-        $splits = $this->splitBranch($branch);
+        if ($onlyChangesSince !== null) {
+            $changedFiles = $this->git->getFileChangesBetween($onlyChangesSince, $branch);
+        }
+
+        $splits = $this->splitBranch($branch, $changedFiles ?? []);
 
         // Check if there are any splits to prevent duplicate messages.
         if (\count($splits) === 0) {
@@ -189,6 +193,8 @@ class BranchSplitsh
 
                 continue;
             }
+
+            $this->style->writeln(\sprintf('<fg=default;bg=default> Tagging split release for directory %s</>', $prefix));
 
             $this->splitshGit->syncTag($versionStr, $split[1], $branch, $split[0]);
             ++$count;

--- a/src/Service/BranchSplitsh.php
+++ b/src/Service/BranchSplitsh.php
@@ -37,14 +37,24 @@ class BranchSplitsh
      * Target configuration and whether this branch should be split et all
      * is automatically resolved from the configuration.
      *
-     * @param string $branch The source branch to split from
-     * @param string $prefix Directory prefix, relative to the root directory
+     * @param string   $branch      The source branch to split from
+     * @param string   $prefix      Directory prefix, relative to the root directory
+     * @param string[] $filterFiles An optional list of files to check if any matches in the $prefix.
+     *                              When passed, only when the files are matched in the prefix the
+     *                              split is performed, null is returned otherwise
      *
      * @return array{0: string, 1: string, 2: string}|null Same as {@link SplitshGit::splitTo}
      */
-    public function splitAtPrefix(string $branch, string $prefix): ?array
+    public function splitAtPrefix(string $branch, string $prefix, array $filterFiles = []): ?array
     {
         $config = $this->getConfigForPrefix($branch, $prefix);
+
+        if ($filterFiles && ! SplitshGit::isPrefixInChangedFiles($prefix, $filterFiles)) {
+            $this->style->note(\sprintf('No changed files where matched for "%s". And the split was ignored.', $prefix));
+
+            return null;
+        }
+
         $this->style->writeln(\sprintf('<fg=default;bg=default> Splitting %s to %s</>', $prefix, $config['url']));
 
         return $this->splitshGit->splitTo($branch, $prefix, $config['url']);
@@ -103,9 +113,12 @@ class BranchSplitsh
      * Split all from the branch to their destinations, unlike splitTo()
      * this will pass when no destinations are found.
      *
+     * @param string[] $filterFiles An optional list of files to check if any matches in the prefixes.
+     *                              When passed, only prefixes matched in the files list are split
+     *
      * @return array<string, array{0: string, 1: string, 2: string}>
      */
-    public function splitBranch(string $branch): array
+    public function splitBranch(string $branch, array $filterFiles = []): array
     {
         $splits = $this->getSplit($this->getBranchConfig($branch));
 
@@ -116,7 +129,10 @@ class BranchSplitsh
         $this->git->ensureBranchInSync(REMOTE_MAIN, $branch);
         $this->splitshGit->checkPrecondition();
 
+        $ignored = [];
         $results = [];
+
+        $splits = SplitshGit::filterOnlyChangedPrefixes($splits, $filterFiles, $ignored);
 
         $this->style->section(\sprintf('Splitting from %s to %d destinations', $branch, \count($splits)));
 
@@ -129,6 +145,11 @@ class BranchSplitsh
 
             $results[$prefix] = $split;
             $this->style->writeln(\sprintf('<fg=default;bg=default> Splitting %s to %s</>', $prefix, $config['url']));
+        }
+
+        if ($ignored) {
+            $this->style->note('No changed files where matched for the following listed prefixes. And the splits have been ignored.');
+            $this->style->listing(array_keys($ignored));
         }
 
         return $results;
@@ -176,15 +197,38 @@ class BranchSplitsh
         return $count;
     }
 
-    public function drySplitAtPrefix(string $branch, string $prefix): void
+    /**
+     * Simulate (dry-run) splitting the prefix directory into another repository.
+     *
+     * Target configuration and whether this branch should be split et all
+     * is automatically resolved from the configuration.
+     *
+     * @param string   $branch      The source branch to split from
+     * @param string   $prefix      Directory prefix, relative to the root directory
+     * @param string[] $filterFiles An optional list of files to check if any matches in the $prefix.
+     *                              When passed, only when the files are matched in the prefix the
+     *                              split is performed, null is returned otherwise
+     */
+    public function drySplitAtPrefix(string $branch, string $prefix, array $filterFiles = []): void
     {
         $config = $this->getConfigForPrefix($branch, $prefix);
+
+        if ($filterFiles && SplitshGit::isPrefixInChangedFiles($prefix, $filterFiles)) {
+            $this->style->note(\sprintf('No changed files where matched for "%s". And the split would have been ignored.', $prefix));
+
+            return;
+        }
 
         $this->style->writeln(\sprintf('<fg=default;bg=default> [DRY-RUN] Splitting %s to %s</>', $prefix, $config['url']));
     }
 
-    /** @return int The number of splits */
-    public function drySplitBranch(string $branch): int
+    /**
+     * @param string[] $filterFiles An optional list of files to check if any matches in the prefixes.
+     *                              When passed, only prefixes matched in the files list are split
+     *
+     * @return int The number of splits
+     */
+    public function drySplitBranch(string $branch, array $filterFiles = []): int
     {
         $splits = $this->getSplit($this->getBranchConfig($branch));
 
@@ -194,10 +238,18 @@ class BranchSplitsh
 
         $this->splitshGit->checkPrecondition();
 
+        $ignored = [];
+        $splits = SplitshGit::filterOnlyChangedPrefixes($splits, $filterFiles, $ignored);
+
         $this->style->section(\sprintf('Would be splitting branch %s to %d destinations', $branch, \count($splits)));
 
         foreach ($splits as $prefix => $config) {
             $this->style->writeln(\sprintf('<fg=default;bg=default> [DRY-RUN] Splitting %s to %s</>', $prefix, $config['url']));
+        }
+
+        if ($ignored) {
+            $this->style->note('No changed files where matched for the following listed prefixes. And the splits would bee ignored.');
+            $this->style->listing(array_keys($ignored));
         }
 
         return \count($splits);

--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -133,9 +133,22 @@ class Git
         return $branch;
     }
 
-    public function getLastTagOnBranch(string $ref = 'HEAD'): string
+    /**
+     * @return ($allowFailure is true ? string|null : string)
+     *
+     * @throws \RuntimeException
+     */
+    public function getLastTagOnBranch(string $ref = 'HEAD', bool $allowFailure = false): ?string
     {
-        return trim($this->process->mustRun(['git', 'describe', '--tags', '--abbrev=0', $ref])->getOutput());
+        try {
+            return trim($this->process->mustRun(['git', 'describe', '--tags', '--abbrev=0', $ref])->getOutput());
+        } catch (\RuntimeException $e) {
+            if (! $allowFailure) {
+                throw $e;
+            }
+
+            return null;
+        }
     }
 
     /** @return array<int, string> ['v1.0', 'v1.5', 'v2.0' '...'] */
@@ -251,6 +264,29 @@ class Git
         );
 
         return array_values(array_filter($results));
+    }
+
+    /**
+     * Returns a list of changed files between two ranges (either commit or branch-name).
+     *
+     * @return string[]
+     */
+    public function getFileChangesBetween(string $start, string $end): array
+    {
+        $results = StringUtil::splitLines($this->process->mustRun(
+            [
+                'git',
+                '--no-pager',
+                'log',
+                '--oneline',
+                '--no-color',
+                '--pretty=format:', // Ensures we only get the names, and not the commit refs
+                '--name-only',
+                $start . '..' . $end,
+            ]
+        )->getOutput());
+
+        return array_values(array_unique(array_filter($results)));
     }
 
     public function remoteBranchExists(string $remote, string $branch): bool

--- a/src/Service/GitHub.php
+++ b/src/Service/GitHub.php
@@ -262,6 +262,17 @@ class GitHub
         ]);
     }
 
+    public function getPullRequestFiles(int $id): iterable
+    {
+        \assert($this->client !== null);
+
+        return (new ResultPager($this->client))->fetchAllLazy($this->client->pullRequest(), 'files', [
+            $this->organization,
+            $this->repository,
+            $id,
+        ]);
+    }
+
     public function getCommitStatuses(string $org, string $repo, string $hash): array
     {
         \assert($this->client !== null);

--- a/src/Service/SplitshGit.php
+++ b/src/Service/SplitshGit.php
@@ -114,4 +114,61 @@ class SplitshGit
             );
         }
     }
+
+    /**
+     * Returns a list of prefixes that are matched in the $changedFiles.
+     *
+     * Note: Prefixes MUST not start or end with a slash.
+     * Files may begin with a begin slash (trimmed).
+     *
+     * @param array<string, array<string, mixed>> $prefixes     ['src/Core' => ..., 'docs'=> ..., 'lib/Bridge/PhpUnit'=> ...]
+     * @param string[]                            $changedFiles ['src/core/SearchFactory.php', '/src/Validator/InputValidator.php']
+     * @param array<string, array<string, mixed>> $ignored      An assoc array with prefixes ignored for not being matched
+     *
+     * @return array<string, array<string, mixed>> The $prefixes filtered
+     */
+    public static function filterOnlyChangedPrefixes(array $prefixes, array $changedFiles, ?array &$ignored): array
+    {
+        $changedFiles = array_unique($changedFiles);
+        $changedFiles = array_map(static fn (string $file): string => ltrim($file, '/'), $changedFiles);
+        $ignored = [];
+
+        if (\count($changedFiles) < 1) {
+            return $prefixes;
+        }
+
+        $pathsList = implode("\n", $changedFiles);
+
+        foreach ($prefixes as $prefix => $config) {
+            if (preg_match_all('#^' . preg_quote($prefix, '#') . '/#mi', $pathsList) < 1) {
+                $ignored[$prefix] = $config;
+                unset($prefixes[$prefix]);
+            }
+        }
+
+        return $prefixes;
+    }
+
+    /**
+     * Returns whether the prefix is matched in the $changedFiles.
+     *
+     * Note: A Prefix MUST not start or end with a slash.
+     * Files may begin with a begin slash (trimmed).
+     *
+     * @param string   $prefix       'src/Core', 'docs', or 'lib/Bridge/PhpUnit'
+     * @param string[] $changedFiles ['src/core/SearchFactory.php', '/src/Validator/InputValidator.php']
+     */
+    public static function isPrefixInChangedFiles(string $prefix, array $changedFiles): bool
+    {
+        $changedFiles = array_unique($changedFiles);
+        $changedFiles = array_map(static fn (string $file): string => ltrim($file, '/'), $changedFiles);
+
+        if (\count($changedFiles) < 1) {
+            return true;
+        }
+
+        $pathsList = implode("\n", $changedFiles);
+
+        return preg_match_all('#^' . preg_quote($prefix, '#') . '/#mi', $pathsList) > 0;
+    }
 }

--- a/tests/ConfigFactoryTest.php
+++ b/tests/ConfigFactoryTest.php
@@ -602,6 +602,7 @@ final class ConfigFactoryTest extends TestCase
                 'pull_request' => [
                     'split' => 'all',
                 ],
+                'release' => ['split' => 'all'],
             ],
             'current_dir' => __DIR__ . '/Fixtures/config/schema_v2_local',
         ]);
@@ -853,6 +854,7 @@ final class ConfigFactoryTest extends TestCase
             'pull_request' => [
                 'split' => 'all',
             ],
+            'release' => ['split' => 'all'],
         ], $config);
 
         $config = $factory->resolveLocalConfig([
@@ -885,6 +887,7 @@ final class ConfigFactoryTest extends TestCase
             'pull_request' => [
                 'split' => 'all',
             ],
+            'release' => ['split' => 'all'],
         ], $config);
     }
 

--- a/tests/ConfigFactoryTest.php
+++ b/tests/ConfigFactoryTest.php
@@ -599,6 +599,9 @@ final class ConfigFactoryTest extends TestCase
                 'adapter' => 'github',
                 'host' => null,
                 'repository' => null,
+                'pull_request' => [
+                    'split' => 'all',
+                ],
             ],
             'current_dir' => __DIR__ . '/Fixtures/config/schema_v2_local',
         ]);
@@ -847,6 +850,9 @@ final class ConfigFactoryTest extends TestCase
             'adapter' => 'github',
             'host' => null,
             'repository' => null,
+            'pull_request' => [
+                'split' => 'all',
+            ],
         ], $config);
 
         $config = $factory->resolveLocalConfig([
@@ -860,6 +866,9 @@ final class ConfigFactoryTest extends TestCase
             'adapter' => 'github',
             'host' => null,
             'repository' => null,
+            'pull_request' => [
+                'split' => 'all',
+            ],
         ]);
 
         self::assertEquals([
@@ -873,6 +882,9 @@ final class ConfigFactoryTest extends TestCase
             'adapter' => 'github',
             'host' => null,
             'repository' => null,
+            'pull_request' => [
+                'split' => 'all',
+            ],
         ], $config);
     }
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -543,4 +543,25 @@ final class ConfigTest extends TestCase
 
         self::assertEquals(['split' => 'changed-only'], $config->getPullRequestConfig());
     }
+
+    /** @test */
+    public function it_gets_release_config(): void
+    {
+        $config = new Config([
+            'schema_version' => 2,
+            'github' => [
+                'github.com' => [
+                    'username' => 'sstok',
+                    'api_token' => 'CHANGE-ME',
+                ],
+            ],
+            '_local' => [
+                'release' => [
+                    'split' => 'changed-only',
+                ],
+            ],
+        ]);
+
+        self::assertEquals(['split' => 'changed-only'], $config->getReleaseConfig());
+    }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -522,4 +522,25 @@ final class ConfigTest extends TestCase
             $config->getBranchConfig('master', 'github.com', 'hubkit-sandbox/empire')
         );
     }
+
+    /** @test */
+    public function it_gets_pull_request_config(): void
+    {
+        $config = new Config([
+            'schema_version' => 2,
+            'github' => [
+                'github.com' => [
+                    'username' => 'sstok',
+                    'api_token' => 'CHANGE-ME',
+                ],
+            ],
+            '_local' => [
+                'pull_request' => [
+                    'split' => 'changed-only',
+                ],
+            ],
+        ]);
+
+        self::assertEquals(['split' => 'changed-only'], $config->getPullRequestConfig());
+    }
 }

--- a/tests/Handler/MergeHandlerTest.php
+++ b/tests/Handler/MergeHandlerTest.php
@@ -1237,6 +1237,254 @@ by who-else at 2014-11-23T14:50:24Z
     }
 
     /** @test */
+    public function it_splits_a_pr_with_only_changed_prefixes(): void
+    {
+        $this->config = new Config([
+            'repositories' => [
+                'github.com' => [
+                    'repos' => [
+                        'park-manager/hubkit' => [],
+                    ],
+                ],
+            ],
+            '_local' => [
+                'sync-tags' => true,
+                'branches' => [
+                    '2.0' => [
+                        'split' => [
+                            'src/Component/Core' => ['url' => 'git@github.com:park-manager/core.git', 'sync-tags' => false],
+                            'src/Component/Model' => ['url' => 'git@github.com:park-manager/model.git', 'sync-tags' => false],
+                            'doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => false],
+                        ],
+                    ],
+                ],
+                'pull_request' => [
+                    'split' => 'changed-only',
+                ],
+            ],
+        ]);
+        $this->config->setActiveRepository('github.com', 'park-manager/hubkit');
+
+        $this->branchSplitsh->splitBranch('master')->shouldNotBeCalled();
+        $this->branchSplitsh->splitBranch('master', $files = ['src/Component/Core/User.php', 'src/doc/brown.php'])->shouldBeCalled();
+
+        $pr = $this->expectPrInfo(fileNames: $files);
+        $this->expectCommitStatus();
+        $this->expectCommits($pr);
+
+        $this->github->mergePullRequest(
+            self::PR_NUMBER,
+            'feature #42 Brand new design (sstok)',
+            PropArgument::exact(<<<'BODY'
+                This PR was merged into the 1.0-dev branch.
+
+                Discussion
+                ----------
+
+                There I fixed it
+
+                Commits
+                -------
+
+                06f57b45415f0456719d578ca5003f9683b941fb Properly handle repository requirement
+                06f57b45415f0456719d578ca5003f9683b941fe PullRequestMergeHandler was already committed
+
+                BODY
+            ),
+            self::HEAD_SHA,
+            false
+        )->willReturn(['sha' => self::MERGE_SHA]);
+
+        $this->expectNotes();
+        $this->expectMetadata('feature', $pr['title']);
+        $this->expectLocalUpdate();
+        $this->expectLocalBranchExists();
+
+        $args = $this->getArgs();
+        $args->setArgument('number', '42');
+        $this->executeHandler($args, 'feature');
+
+        $this->assertOutputMatches(
+            [
+                'Pull request has been merged.',
+                'Branch "feature-something" was deleted.',
+                'Your local "master" branch is updated.',
+            ]
+        );
+    }
+
+    /** @test */
+    public function it_splits_a_pr_full_when_changed_files_is_to_large_and_confirmed(): void
+    {
+        $this->config = new Config([
+            'repositories' => [
+                'github.com' => [
+                    'repos' => [
+                        'park-manager/hubkit' => [],
+                    ],
+                ],
+            ],
+            '_local' => [
+                'sync-tags' => true,
+                'branches' => [
+                    '2.0' => [
+                        'split' => [
+                            'src/Component/Core' => ['url' => 'git@github.com:park-manager/core.git', 'sync-tags' => false],
+                            'src/Component/Model' => ['url' => 'git@github.com:park-manager/model.git', 'sync-tags' => false],
+                            'doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => false],
+                        ],
+                    ],
+                ],
+                'pull_request' => [
+                    'split' => 'changed-only',
+                ],
+            ],
+        ]);
+        $this->config->setActiveRepository('github.com', 'park-manager/hubkit');
+
+        $this->branchSplitsh->splitBranch('master')->shouldNotBeCalled();
+        $this->branchSplitsh->splitBranch('master', [])->shouldBeCalled();
+
+        $files = [];
+
+        for ($i = 1; $i < 305; ++$i) {
+            $files[] = 'src/Component/User/File' . $i;
+        }
+
+        $pr = $this->expectPrInfo(fileNames: $files);
+        $this->expectCommitStatus();
+        $this->expectCommits($pr);
+
+        $this->github->mergePullRequest(
+            self::PR_NUMBER,
+            'feature #42 Brand new design (sstok)',
+            PropArgument::exact(<<<'BODY'
+                This PR was merged into the 1.0-dev branch.
+
+                Discussion
+                ----------
+
+                There I fixed it
+
+                Commits
+                -------
+
+                06f57b45415f0456719d578ca5003f9683b941fb Properly handle repository requirement
+                06f57b45415f0456719d578ca5003f9683b941fe PullRequestMergeHandler was already committed
+
+                BODY
+            ),
+            self::HEAD_SHA,
+            false
+        )->willReturn(['sha' => self::MERGE_SHA]);
+
+        $this->expectNotes();
+        $this->expectMetadata('feature', $pr['title']);
+        $this->expectLocalUpdate();
+        $this->expectLocalBranchExists();
+
+        $args = $this->getArgs();
+        $args->setArgument('number', '42');
+        $this->executeHandler($args, 'feature', ['yes']);
+
+        $this->assertOutputMatches(
+            [
+                'Pull request has been merged.',
+                'Branch "feature-something" was deleted.',
+                'Your local "master" branch is updated.',
+                'More than 300 files have been changed. Cannot perform a changed-only split.',
+                'Do you want to continue with a complete split instead?',
+            ]
+        );
+    }
+
+    /** @test */
+    public function it_skips_splits_when_changed_files_is_to_large_and_not_confirmed(): void
+    {
+        $this->config = new Config([
+            'repositories' => [
+                'github.com' => [
+                    'repos' => [
+                        'park-manager/hubkit' => [],
+                    ],
+                ],
+            ],
+            '_local' => [
+                'sync-tags' => true,
+                'branches' => [
+                    '2.0' => [
+                        'split' => [
+                            'src/Component/Core' => ['url' => 'git@github.com:park-manager/core.git', 'sync-tags' => false],
+                            'src/Component/Model' => ['url' => 'git@github.com:park-manager/model.git', 'sync-tags' => false],
+                            'doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => false],
+                        ],
+                    ],
+                ],
+                'pull_request' => [
+                    'split' => 'changed-only',
+                ],
+            ],
+        ]);
+        $this->config->setActiveRepository('github.com', 'park-manager/hubkit');
+
+        $this->branchSplitsh->splitBranch('master')->shouldNotBeCalled();
+        $this->branchSplitsh->splitBranch('master', [])->shouldNotBeCalled();
+
+        $files = [];
+
+        for ($i = 1; $i < 305; ++$i) {
+            $files[] = 'src/Component/User/File' . $i;
+        }
+
+        $pr = $this->expectPrInfo(fileNames: $files);
+        $this->expectCommitStatus();
+        $this->expectCommits($pr);
+
+        $this->github->mergePullRequest(
+            self::PR_NUMBER,
+            'feature #42 Brand new design (sstok)',
+            PropArgument::exact(<<<'BODY'
+                This PR was merged into the 1.0-dev branch.
+
+                Discussion
+                ----------
+
+                There I fixed it
+
+                Commits
+                -------
+
+                06f57b45415f0456719d578ca5003f9683b941fb Properly handle repository requirement
+                06f57b45415f0456719d578ca5003f9683b941fe PullRequestMergeHandler was already committed
+
+                BODY
+            ),
+            self::HEAD_SHA,
+            false
+        )->willReturn(['sha' => self::MERGE_SHA]);
+
+        $this->expectNotes();
+        $this->expectMetadata('feature', $pr['title']);
+        $this->expectLocalUpdate();
+        $this->expectLocalBranchExists();
+
+        $args = $this->getArgs();
+        $args->setArgument('number', '42');
+        $this->executeHandler($args, 'feature', ['no']);
+
+        $this->assertOutputMatches(
+            [
+                'Pull request has been merged.',
+                'Branch "feature-something" was deleted.',
+                'Your local "master" branch is updated.',
+                'More than 300 files have been changed. Cannot perform a changed-only split.',
+                'Do you want to continue with a complete split instead?',
+                'Split was skipped.',
+            ]
+        );
+    }
+
+    /** @test */
     public function it_checks_pr_is_open(): void
     {
         $this->expectPrInfo('sstok', [], 'closed');
@@ -1468,6 +1716,7 @@ by who-else at 2014-11-23T14:50:24Z
         string $body = 'There I fixed it',
         string $base = 'master',
         array $reviews = [],
+        array $fileNames = [],
     ): array {
         $number = self::PR_NUMBER;
 
@@ -1493,7 +1742,13 @@ by who-else at 2014-11-23T14:50:24Z
                 ),
             ]
         );
+
         $this->github->getPullRequestReviews($number)->willReturn($reviews);
+
+        if ($fileNames) {
+            $fileNames = array_map(static fn (string $file): array => ['filename' => $file], $fileNames);
+            $this->github->getPullRequestFiles($number)->willReturn($fileNames);
+        }
 
         return $pr;
     }

--- a/tests/Handler/ReleaseHandlerTest.php
+++ b/tests/Handler/ReleaseHandlerTest.php
@@ -183,6 +183,140 @@ labels: removed-deprecation
     }
 
     /** @test */
+    public function it_creates_a_new_release_with_changed_only_split_without_existing_tags(): void
+    {
+        $this->config = new Config(
+            [
+                '_local' => [
+                    'branches' => [
+                        ':default' => [
+                            'split' => [
+                                'src/Component/Core' => ['url' => 'git@github.com:park-manager/core.git', 'sync-tags' => true],
+                                'src/Component/Model' => ['url' => 'git@github.com:park-manager/model.git', 'sync-tags' => true],
+                                'doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => false],
+                            ],
+                        ],
+                    ],
+                    'release' => ['split' => 'changed-only'],
+                ],
+            ],
+        );
+        $this->config->setActiveRepository('github.com', 'park-manager/park-manager');
+
+        $this->expectTags([], 'master');
+        $this->expectMatchingVersionBranchNotExists();
+        $this->expectEditorReturns('Initial release.');
+
+        $url = $this->expectTagAndGitHubRelease('1.0.0', 'Initial release.', branch: 'master', since: null);
+
+        $args = $this->getArgs('1.0');
+        $this->executeHandler($args);
+
+        $this->assertOutputMatches(
+            [
+                'Provided version: 1.0.0',
+                'Preparing release 1.0.0 (target branch master)',
+                'Please wait...',
+                'Successfully released 1.0.0',
+                $url,
+            ]
+        );
+
+        $this->assertOutputNotMatches('Creating split-releases only for changes since');
+    }
+
+    /** @test */
+    public function it_creates_a_new_release_with_changed_only_split_with_existing_tags(): void
+    {
+        $this->config = new Config(
+            [
+                '_local' => [
+                    'branches' => [
+                        ':default' => [
+                            'split' => [
+                                'src/Component/Core' => ['url' => 'git@github.com:park-manager/core.git', 'sync-tags' => true],
+                                'src/Component/Model' => ['url' => 'git@github.com:park-manager/model.git', 'sync-tags' => true],
+                                'doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => false],
+                            ],
+                        ],
+                    ],
+                    'release' => ['split' => 'changed-only'],
+                ],
+            ],
+        );
+        $this->config->setActiveRepository('github.com', 'park-manager/park-manager');
+
+        $this->expectTags(['1.2.0', '2.0.0'], 'master');
+        $this->expectMatchingVersionBranchNotExists('2.1');
+
+        $this->git->getLogBetweenCommits('2.0.0', 'master')->willReturn(self::COMMITS);
+
+        $this->expectEditorReturns("### Added\n- Introduce a new API for ValuesBag");
+
+        $url = $this->expectTagAndGitHubRelease('2.1.0', "### Added\n- Introduce a new API for ValuesBag", branch: 'master', since: '2.0.0');
+
+        $args = $this->getArgs('2.1');
+        $this->executeHandler($args);
+
+        $this->assertOutputMatches(
+            [
+                'Provided version: 2.1.0',
+                'Preparing release 2.1.0 (target branch master)',
+                'Please wait...',
+                'Creating split-releases only for changes since "2.0.0".',
+                'Successfully released 2.1.0',
+                $url,
+            ]
+        );
+    }
+
+    /** @test */
+    public function it_creates_a_new_release_with_changed_only_split_forced_all(): void
+    {
+        $this->config = new Config(
+            [
+                '_local' => [
+                    'branches' => [
+                        ':default' => [
+                            'split' => [
+                                'src/Component/Core' => ['url' => 'git@github.com:park-manager/core.git', 'sync-tags' => true],
+                                'src/Component/Model' => ['url' => 'git@github.com:park-manager/model.git', 'sync-tags' => true],
+                                'doc' => ['url' => 'git@github.com:park-manager/doc.git', 'sync-tags' => false],
+                            ],
+                        ],
+                    ],
+                    'release' => ['split' => 'changed-only'],
+                ],
+            ],
+        );
+        $this->config->setActiveRepository('github.com', 'park-manager/park-manager');
+
+        $this->expectTags(['1.2.0', '2.0.0'], 'master');
+        $this->expectMatchingVersionBranchNotExists('2.1');
+
+        $this->git->getLogBetweenCommits('2.0.0', 'master')->willReturn(self::COMMITS);
+        $this->expectEditorReturns("### Added\n- Introduce a new API for ValuesBag");
+
+        $url = $this->expectTagAndGitHubRelease('2.1.0', "### Added\n- Introduce a new API for ValuesBag");
+
+        $args = $this->getArgs('2.1');
+        $args->setOption('force-split-all', true);
+        $this->executeHandler($args);
+
+        $this->assertOutputMatches(
+            [
+                'Provided version: 2.1.0',
+                'Preparing release 2.1.0 (target branch master)',
+                'Please wait...',
+                'Successfully released 2.1.0',
+                $url,
+            ]
+        );
+
+        $this->assertOutputNotMatches('Creating split-releases only for changes since');
+    }
+
+    /** @test */
     public function it_creates_a_new_release_for_current_branch_with_existing_tags_and_no_gap(): void
     {
         $this->expectTags(['0.1.0', '1.0.0-BETA1']);
@@ -383,6 +517,7 @@ labels: removed-deprecation
             ->addOption(new Option('all-categories', null, Option::NO_VALUE | Option::BOOLEAN))
             ->addOption(new Option('no-edit', null, Option::NO_VALUE | Option::BOOLEAN))
             ->addOption(new Option('pre-release', null, Option::BOOLEAN))
+            ->addOption(new Option('force-split-all', null, Option::BOOLEAN))
             ->addOption(new Option('title', null, Option::REQUIRED_VALUE | Option::NULLABLE | Option::STRING))
             ->addArgument(new Argument('version', Argument::REQUIRED | Argument::STRING))
             ->getFormat()
@@ -411,7 +546,7 @@ labels: removed-deprecation
         $handler->handle($args, $this->io);
     }
 
-    private function expectTags(array $tags = []): void
+    private function expectTags(array $tags = [], ?string $branch = 'HEAD'): void
     {
         $process = $this->prophesize(Process::class);
         $process->getOutput()->willReturn(implode("\n", $tags));
@@ -420,8 +555,10 @@ labels: removed-deprecation
 
         if ($tags === []) {
             $this->git->getLastTagOnBranch()->willThrow(ProcessFailedException::class);
+            $this->git->getLastTagOnBranch($branch, true)->willReturn(null);
         } else {
-            $this->git->getLastTagOnBranch()->willReturn(end($tags));
+            $this->git->getLastTagOnBranch()->willReturn($lastTag = end($tags));
+            $this->git->getLastTagOnBranch($branch, true)->willReturn($lastTag);
         }
     }
 
@@ -435,9 +572,13 @@ labels: removed-deprecation
         $this->git->remoteBranchExists(REMOTE_MAIN, $branch)->willReturn(false);
     }
 
-    private function expectTagAndGitHubRelease(string $version, string $message, ?string $title = null, ?string $branch = null): string
+    private function expectTagAndGitHubRelease(string $version, string $message, ?string $title = null, ?string $branch = null, string | false | null $since = false): string
     {
-        $this->branchSplitsh->syncTags($branch ?? 'master', $version)->willReturn(2)->shouldBeCalled();
+        if ($since !== false) {
+            $this->branchSplitsh->syncTags($branch ?? 'master', $version, $since)->willReturn(1)->shouldBeCalled();
+        } else {
+            $this->branchSplitsh->syncTags($branch ?? 'master', $version)->willReturn(2)->shouldBeCalled();
+        }
 
         $this->process->mustRun(['git', 'tag', '-s', 'v' . $version, '-m', 'Release ' . $version])->shouldBeCalled();
         $this->process->mustRun(['git', 'push', REMOTE_MAIN, 'v' . $version])->shouldBeCalled();

--- a/tests/Service/BranchSplitshTest.php
+++ b/tests/Service/BranchSplitshTest.php
@@ -179,6 +179,20 @@ final class BranchSplitshTest extends TestCase
     }
 
     /** @test */
+    public function splits_prefix_to_destinations_ignored_unchanged_prefixes(): void
+    {
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '2.1')->shouldBeCalled();
+        $this->expectGitSplit('lobster', 'git@github.com:hubkit-sandbox/pinchy.git', 'cc1', '2.1');
+
+        self::assertNull($this->getBranchSplitsh()->splitAtPrefix('2.1', 'lobster', ['src/lobster']));
+
+        $this->assertOutputMatches([
+            'Repository-split configuration for branch 2.1 resolved from 2.x.',
+            'No changed files where matched for "lobster". And the split was ignored.',
+        ]);
+    }
+
+    /** @test */
     public function split_prefix_to_destinations_fails_for_missing_prefix_configuration(): void
     {
         $this->git->ensureBranchInSync(REMOTE_MAIN, '4.1')->shouldBeCalled();
@@ -210,6 +224,33 @@ final class BranchSplitshTest extends TestCase
             'Splitting from 4.0 to 2 destinations',
             'Splitting src/Module/CoreModule to git@github.com:hubkit-sandbox/core-module.git',
             'Splitting src/Module/WebhostingModule to git@github.com:hubkit-sandbox/webhosting-module.git',
+        ]);
+    }
+
+    /** @test */
+    public function splits_branch_to_destinations_ignoring_unchanged_prefixes(): void
+    {
+        $this->git->ensureBranchInSync(REMOTE_MAIN, '4.0')->shouldBeCalled();
+        $this->expectGitSplit('src/Module/CoreModule', 'git@github.com:hubkit-sandbox/core-module.git', 'cc1', '4.0');
+
+        self::assertEquals(
+            [
+                'src/Module/CoreModule' => ['/tmp/hubkit/stor/src/Module/CoreModule' => ['cc1', 'git@github.com:hubkit-sandbox/core-module.git']],
+            ],
+            $this->getBranchSplitsh()->splitBranch('4.0', [
+                'src/Module/CoreModule/CoreModule.php',
+                'src/Module/CoreModule/DependencyInjection/Configuration.php',
+                'src/Module/UserModule/DependencyInjection/Configuration.php',
+                'doc/Module/WebhostingModule/index.rst',
+            ])
+        );
+
+        $this->assertOutputMatches([
+            'Repository-split configuration for branch 4.0 resolved from :default.',
+            'Splitting from 4.0 to 1 destination',
+            'Splitting src/Module/CoreModule to git@github.com:hubkit-sandbox/core-module.git',
+            'No changed files where matched for the following listed prefixes. And the splits have been ignored.',
+            '* src/Module/WebhostingModule',
         ]);
     }
 

--- a/tests/Service/SplitshGitTest.php
+++ b/tests/Service/SplitshGitTest.php
@@ -154,6 +154,62 @@ final class SplitshGitTest extends TestCase
         $service->checkPrecondition();
     }
 
+    /** @test */
+    public function it_gets_only_changed_prefixes(): void
+    {
+        $this->assertSame(
+            [],
+            SplitshGit::filterOnlyChangedPrefixes(
+                ['src/Core' => []],
+                [
+                    'src/User/User.php',
+                    'src/Core2/SearchFactory.php',
+                ],
+                $ignored,
+            ),
+        );
+        $this->assertEquals(['src/Core' => []], $ignored);
+
+        $this->assertSame(
+            ['src/Core' => []],
+            SplitshGit::filterOnlyChangedPrefixes(
+                ['src/Core' => [], 'src/Validator' => []],
+                [
+                    'src/User/User.php',
+                    'src/Core/SearchFactory.php',
+                ],
+                $ignored
+            ),
+        );
+        $this->assertEquals(['src/Validator' => []], $ignored);
+
+        $this->assertSame(
+            ['src/Core' => [], 'src/User' => []],
+            SplitshGit::filterOnlyChangedPrefixes(
+                ['src/Core' => [], 'src/User' => []],
+                [
+                    'src/User/User.php',
+                    'src/Core/SearchFactory.php',
+                ],
+                $ignored
+            ),
+        );
+        $this->assertEquals([], $ignored);
+
+        $this->assertSame(
+            ['src/Core' => []],
+            SplitshGit::filterOnlyChangedPrefixes(
+                ['src/Core' => [], 'src/User' => []],
+                [
+                    'src/User.php',
+                    'src/Core/SearchFactory.php',
+                ],
+                $ignored
+            ),
+        );
+        $this->assertEquals(['src/User' => []], $ignored);
+    }
+
     private function getGitSplitShResult(string $hash): Process
     {
         $processProphecy = $this->prophesize(Process::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | Fix #135 
| License       | MIT

- Allow to merge a pull request, splitting only the changed prefixes (limited to checking 300 files max).
- Allow to create split releases only for prefixes that have changed since the last tag (on the branch), can be overwritten using an argument option.

Todo: Real life testing, ~~documentation~~. ~And fix phpstan errors.~