### PR TITLE
More helpful message for repo-split with prefix

### DIFF
--- a/src/Cli/Handler/SplitRepoHandler.php
+++ b/src/Cli/Handler/SplitRepoHandler.php
@@ -32,7 +32,7 @@ final class SplitRepoHandler extends GitBaseHandler
         parent::__construct($style, $git, $github, $config);
     }
 
-    public function handle(Args $args): void
+    public function handle(Args $args): ?int
     {
         $this->git->guardWorkingTreeReady();
         $this->git->remoteUpdate(REMOTE_MAIN);
@@ -46,9 +46,7 @@ final class SplitRepoHandler extends GitBaseHandler
         $this->guardMaintained($branch);
 
         if ($prefix !== null) {
-            $this->splitPrefixOnly($branch, $prefix, $args->getOption('dry-run'));
-
-            return;
+            return $this->splitPrefixOnly($branch, $prefix, $args->getOption('dry-run'));
         }
 
         if ($args->getOption('dry-run')) {
@@ -56,12 +54,14 @@ final class SplitRepoHandler extends GitBaseHandler
                 $this->style->success('[DRY-RUN] Repository directories were split into there destination.');
             }
 
-            return;
+            return null;
         }
 
         if (\count($this->branchSplitsh->splitBranch($branch)) > 0) {
             $this->style->success('Repository directories were split into there destination.');
         }
+
+        return null;
     }
 
     private function getBranchName(Args $args): string
@@ -77,17 +77,52 @@ final class SplitRepoHandler extends GitBaseHandler
         return $branch;
     }
 
-    private function splitPrefixOnly(string $branch, string $prefix, bool $dryRun): void
+    private function splitPrefixOnly(string $branch, string $prefix, bool $dryRun): ?int
     {
-        if ($dryRun) {
-            $this->branchSplitsh->drySplitAtPrefix($branch, $prefix);
-            $this->style->success(\sprintf('[DRY-RUN] Repository directory "%s" were split into there destination.', $prefix));
+        try {
+            if ($dryRun) {
+                $this->branchSplitsh->drySplitAtPrefix($branch, $prefix);
+                $this->style->success(\sprintf('[DRY-RUN] Repository directory "%s" was split into it\'s destination.', $prefix));
 
-            return;
-        }
+                return null;
+            }
 
-        if ($this->branchSplitsh->splitAtPrefix($branch, $prefix) !== null) {
-            $this->style->success(\sprintf('Repository directory "%s" were split into there destination.', $prefix));
+            if ($this->branchSplitsh->splitAtPrefix($branch, $prefix) !== null) {
+                $this->style->success(\sprintf('Repository directory "%s" was split into it\'s destination.', $prefix));
+            }
+
+            return null;
+        } catch (\InvalidArgumentException $e) {
+            if ($e->getCode() !== 50) {
+                throw $e;
+            }
+
+            $branchConfig = $this->config->getBranchConfig($branch);
+            $found = null;
+
+            /** @var string $p */
+            foreach ($branchConfig->config['split'] ?? [] as $p => $d) {
+                // See if we can find one with a different case matching.
+                if (strcasecmp($p, $prefix) === 0) {
+                    $found = $p;
+
+                    break;
+                }
+            }
+
+            $this->style->error($e->getMessage());
+            $this->style->writeln(' The following prefixes are available for this branch:');
+            $this->style->listing(array_keys($branchConfig->config['split']));
+
+            if ($found !== null) {
+                $this->style->info('A prefixes with a different casing was found.');
+
+                if ($this->style->confirm(\sprintf('Did you mean "%s"?', $found))) {
+                    return $this->splitPrefixOnly($branch, $found, $dryRun);
+                }
+            }
+
+            return 1;
         }
     }
 }

--- a/src/Service/BranchSplitsh.php
+++ b/src/Service/BranchSplitsh.php
@@ -73,7 +73,8 @@ class BranchSplitsh
                     'Unable to split repository at prefix: No entry found for "[%s][split][%s]".',
                     implode('][', $branchConfig->configPath),
                     $prefix
-                )
+                ),
+                50
             );
         }
 
@@ -85,7 +86,8 @@ class BranchSplitsh
                     'Unable to split repository at prefix: Entry is disabled for "[%s][split][%s]".',
                     implode('][', $branchConfig->configPath),
                     $prefix
-                )
+                ),
+                5
             );
         }
 

--- a/tests/Handler/SplitRepoHandlerTest.php
+++ b/tests/Handler/SplitRepoHandlerTest.php
@@ -181,7 +181,7 @@ final class SplitRepoHandlerTest extends TestCase
         $this->assertOutputMatches(
             [
                 'Working on hubkit-sandbox/empire (branch master)',
-                'Repository directory "src/Module/CoreModule" were split into there destination.',
+                'Repository directory "src/Module/CoreModule" was split into it\'s destination.',
             ]
         );
     }
@@ -201,7 +201,66 @@ final class SplitRepoHandlerTest extends TestCase
         $this->assertOutputMatches(
             [
                 'Working on hubkit-sandbox/empire (branch master)',
-                '[DRY-RUN] Repository directory "src/Module/CoreModule" were split into there destination.',
+                '[DRY-RUN] Repository directory "src/Module/CoreModule" was split into it\'s destination.',
+            ]
+        );
+    }
+
+    /** @test */
+    public function it_lists_available_when_prefix_is_not_found(): void
+    {
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '1.1')->shouldBeCalled();
+        $this->splitshGit->splitAtPrefix('1.1', 'CoreModule')->willThrow(
+            new \InvalidArgumentException('Unable to split repository at prefix: No entry found for "[CoreModule]".', 50)
+        );
+
+        $args = $this->getArgs();
+        $args->setArgument('branch', '1.1');
+        $args->setOption('prefix', 'CoreModule');
+
+        $this->assertSame(1, $this->executeHandler($args));
+
+        $this->assertOutputMatches(
+            [
+                'Working on hubkit-sandbox/empire (branch 1.1)',
+                'Unable to split repository at prefix: No entry found for "[CoreModule]".',
+                'The following prefixes are available for this branch:',
+                ' * src/Module/CoreModule',
+                ' * src/Module/CoreModule',
+                ' * src/Module/WebhostingModule',
+                ' * docs',
+                ' * noop',
+            ]
+        );
+    }
+
+    /** @test */
+    public function it_gives_suggestions_when_prefix_case_mismatches(): void
+    {
+        $this->git->checkoutRemoteBranch(REMOTE_MAIN, '1.1')->shouldBeCalled();
+        $this->splitshGit->splitAtPrefix('1.1', 'Docs')->willThrow(
+            new \InvalidArgumentException('Unable to split repository at prefix: No entry found for "[Docs]".', 50)
+        );
+        $this->splitshGit->splitAtPrefix('1.1', 'docs')->shouldBeCalled();
+
+        $args = $this->getArgs();
+        $args->setArgument('branch', '1.1');
+        $args->setOption('prefix', 'Docs');
+
+        $this->assertNull($this->executeHandler($args, ['yes']));
+
+        $this->assertOutputMatches(
+            [
+                'Working on hubkit-sandbox/empire (branch 1.1)',
+                'Unable to split repository at prefix: No entry found for "[Docs]".',
+                'The following prefixes are available for this branch:',
+                ' * src/Module/CoreModule',
+                ' * src/Module/CoreModule',
+                ' * src/Module/WebhostingModule',
+                ' * docs',
+                ' * noop',
+                'A prefixes with a different casing was found.',
+                'Did you mean "docs"?',
             ]
         );
     }
@@ -218,7 +277,7 @@ final class SplitRepoHandlerTest extends TestCase
         return new Args($format, new StringArgs(''));
     }
 
-    private function executeHandler(?Args $args, array $input = []): void
+    private function executeHandler(?Args $args, array $input = []): ?int
     {
         $style = $this->createStyle($input);
         $handler = new SplitRepoHandler(
@@ -229,6 +288,6 @@ final class SplitRepoHandlerTest extends TestCase
             $this->splitshGit->reveal(),
         );
 
-        $handler->handle($args ?? $this->getArgs());
+        return $handler->handle($args ?? $this->getArgs());
     }
 }

--- a/tests/Service/BranchSplitshTest.php
+++ b/tests/Service/BranchSplitshTest.php
@@ -198,7 +198,7 @@ final class BranchSplitshTest extends TestCase
         $this->git->ensureBranchInSync(REMOTE_MAIN, '4.1')->shouldBeCalled();
 
         $this->expectExceptionObject(new \InvalidArgumentException(
-            'Unable to split repository at prefix: No entry found for "[repositories][github.com][repos][hubkit-sandbox/empire][branches][:default][split][pinchy]".'
+            'Unable to split repository at prefix: No entry found for "[repositories][github.com][repos][hubkit-sandbox/empire][branches][:default][split][pinchy]".', 50
         ));
 
         $this->getBranchSplitsh()->splitAtPrefix('4.1', 'pinchy');
@@ -367,7 +367,7 @@ final class BranchSplitshTest extends TestCase
         $this->git->ensureBranchInSync(REMOTE_MAIN, '2.1')->shouldBeCalled();
 
         $this->expectExceptionObject(new \InvalidArgumentException(
-            'Unable to split repository at prefix: No entry found for "[repositories][github.com][repos][hubkit-sandbox/empire][branches][2.x][split][pinchy]".'
+            'Unable to split repository at prefix: No entry found for "[repositories][github.com][repos][hubkit-sandbox/empire][branches][2.x][split][pinchy]".', 50
         ));
 
         $this->getBranchSplitsh()->drySplitAtPrefix('2.1', 'pinchy');
@@ -379,7 +379,7 @@ final class BranchSplitshTest extends TestCase
         $this->git->ensureBranchInSync(REMOTE_MAIN, '6.1')->shouldBeCalled();
 
         $this->expectExceptionObject(new \InvalidArgumentException(
-            'Unable to split repository at prefix: Entry is disabled for "[repositories][github.com][repos][hubkit-sandbox/empire][branches][6.x][split][src/Module/WebhostingModule]".'
+            'Unable to split repository at prefix: Entry is disabled for "[repositories][github.com][repos][hubkit-sandbox/empire][branches][6.x][split][src/Module/WebhostingModule]".', 5
         ));
 
         $this->getBranchSplitsh()->drySplitAtPrefix('6.1', 'src/Module/WebhostingModule');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT

Inform which prefixes are available, and when there is only a case mismatch suggest to execute with the correct casing instead.


```markdown
$ hk split-repo --prefix lib/noo

Repository Split
================

Working on hubkit-sandbox/search (branch main)

 ! [NOTE] Using local configuration from branch "_hubkit".

 Repository-split configuration for branch main resolved from :default.

 [ERROR] Unable to split repository at prefix: No entry found for "[_local][branches][:default][split][lib/noo]".

 The following prefixes are available for this branch:
 * lib/ApiPlatform
 * lib/Core
 * lib/Doctrine/Dbal
 * lib/Doctrine/Orm
 * lib/Elasticsearch
 * lib/Symfony/SearchBundle
 * lib/Symfony/Validator
```

```markdown
$ hk split-repo --prefix lib/core

Repository Split
================

Working on hubkit-sandbox/search (branch main)

 ! [NOTE] Using local configuration from branch "_hubkit".

 Repository-split configuration for branch main resolved from :default.

 [ERROR] Unable to split repository at prefix: No entry found for "[_local][branches][:default][split][lib/core]".

 The following prefixes are available for this branch:
 * lib/ApiPlatform
 * lib/Core
 * lib/Doctrine/Dbal
 * lib/Doctrine/Orm
 * lib/Elasticsearch
 * lib/Symfony/SearchBundle
 * lib/Symfony/Validator

 [INFO] A prefixes with a different casing was found.

 Did you mean "lib/Core"? (yes/no) [yes]:
 > yes

 Repository-split configuration for branch main resolved from :default.
 Splitting lib/Core to git@github.com:hubkit-sandbox/search-core.git

 [OK] Repository directory "lib/Core" was split into it's destination.
```
