### PR TITLE
Disallow extra keys for local configuration

### DIFF
--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -385,7 +385,6 @@ final class ConfigFactory
     {
         $treeBuilder = new TreeBuilder('hubkit');
         $treeBuilder->getRootNode()
-            ->ignoreExtraKeys(false)
             ->children()
                 ->integerNode('schema_version')
                     ->isRequired()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT

This was done previously as the configuration tree wasn't stable but we are entering the feature freeze now.
To prevent any wrong configuration only defined keys are now accepted.

