### PR TITLE
Sync-configuration fails without local branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "phpstan/phpstan-phpunit": "^1.1.1",
         "phpstan/phpstan-symfony": "^1.2",
         "phpunit/phpunit": "^9.5.21",
-        "rollerscapes/standards": "^1.0",
+        "rollerscapes/standards": "^0.2",
         "symfony/phpunit-bridge": "^6.0"
     },
     "repositories": [

--- a/src/Cli/Handler/SynchronizeConfigHandler.php
+++ b/src/Cli/Handler/SynchronizeConfigHandler.php
@@ -46,6 +46,11 @@ final class SynchronizeConfigHandler extends GitBaseHandler
 
                 return 0;
 
+            case Git::STATUS_NEED_BRANCH:
+                $this->style->info('Remote "_hubkit" branch exists, missing locally.');
+                $this->setupRemoteBranch();
+                $this->style->success('Successfully created local branch "_hubkit".');
+
             case Git::STATUS_NEED_PULL:
                 $this->style->note('Pulling changes.');
                 $this->git->fetchRemote(REMOTE_MAIN, '_hubkit:_hubkit');
@@ -62,5 +67,17 @@ final class SynchronizeConfigHandler extends GitBaseHandler
         }
 
         throw new \RuntimeException('The remote "_hubkit" branch and local branch have diverged. Cannot safely continue, resolve this problem manually.');
+    }
+
+    private function setupRemoteBranch(): void
+    {
+        $currentBranch = $this->git->getActiveBranchName();
+
+        try {
+            $this->git->checkoutRemoteBranch(REMOTE_MAIN, '_hubkit');
+            $this->git->trackRemoteBranch(REMOTE_MAIN, '_hubkit');
+        } finally {
+            $this->git->checkout($currentBranch);
+        }
     }
 }

--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -24,6 +24,7 @@ class Git
 {
     final public const STATUS_UP_TO_DATE = 'up-to-date';
     final public const STATUS_NEED_PULL = 'need_pull';
+    final public const STATUS_NEED_BRANCH = 'need_branch';
     final public const STATUS_NEED_PUSH = 'need_push';
     final public const STATUS_DIVERGED = 'diverged';
 
@@ -55,9 +56,7 @@ class Git
     /**
      * Gets the diff status of the remote and local.
      *
-     * @return string Returns the value of one of the following constants:
-     *                GitHelper::STATUS_UP_TO_DATE, GitHelper::STATUS_NEED_PULL
-     *                GitHelper::STATUS_NEED_PUSH, GitHelper::STATUS_DIVERGED
+     * @return self::STATUS_*
      *
      * @see https://gist.github.com/WebPlatformDocs/437f763b948c926ca7ba
      * @see https://stackoverflow.com/questions/3258243/git-check-if-pull-needed
@@ -70,6 +69,10 @@ class Git
 
         if (! $this->remoteBranchExists($remoteName, $remoteBranch)) {
             return self::STATUS_NEED_PUSH;
+        }
+
+        if (! $this->branchExists($localBranch)) {
+            return self::STATUS_NEED_BRANCH;
         }
 
         $localRef = $this->process->mustRun(['git', 'rev-parse', $localBranch])->getOutput();
@@ -456,6 +459,11 @@ class Git
         }
 
         $this->process->mustRun($cmd);
+    }
+
+    public function trackRemoteBranch(string $remote, string $branchName): void
+    {
+        $this->process->mustRun(['git', 'branch', '--set-upstream-to', $remote . '/' . $branchName, $branchName]);
     }
 
     public function guardWorkingTreeReady(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

If the remote branch exists but the local branch is missing the `sync-config` command fails with a missing ref.

