### PR TITLE
Add CleanupUnmaintainedHandler

### DIFF
--- a/src/Cli/Handler/CleanupUnmaintainedHandler.php
+++ b/src/Cli/Handler/CleanupUnmaintainedHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HuPKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Cli\Handler;
+
+use HubKit\Config;
+use HubKit\Service\Git;
+use HubKit\Service\GitHub;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Console\Api\Args\Args;
+
+final class CleanupUnmaintainedHandler extends GitBaseHandler
+{
+    public function __construct(
+        SymfonyStyle $style,
+        Git $git,
+        GitHub $github,
+        Config $config,
+    ) {
+        parent::__construct($style, $git, $github, $config);
+    }
+
+    public function handle(Args $args): void
+    {
+        $this->informationHeader();
+
+        $defaultBranch = $this->config->getMainBranch();
+        $unmaintainedBranches = [];
+
+        foreach ($this->config->get(['_local', 'branches'], []) as $branch => $config) {
+            if ($branch === ':default' || $branch === $defaultBranch) {
+                continue;
+            }
+
+            if ($config['maintained'] === false && $this->git->branchExists($branch)) {
+                $unmaintainedBranches[] = $branch;
+            }
+        }
+
+        if ($unmaintainedBranches === []) {
+            $this->style->success('No unmaintained branches found.');
+
+            return;
+        }
+
+        $this->style->warning('The following local branches are unmaintained and can be deleted.' . "\n\n * " . implode("\n * ", $unmaintainedBranches));
+
+        if (! $this->style->confirm('Delete these local branches now?', true)) {
+            throw new \RuntimeException('User aborted.');
+        }
+
+        foreach ($unmaintainedBranches as $branch) {
+            $this->style->note(\sprintf('Deleting branch "%s"...', $branch));
+            $this->git->deleteBranchWithForce($branch);
+        }
+
+        $this->style->success('All unmaintained branches were deleted.');
+    }
+}

--- a/src/Cli/HubKitApplicationConfig.php
+++ b/src/Cli/HubKitApplicationConfig.php
@@ -205,6 +205,18 @@ final class HubKitApplicationConfig extends DefaultApplicationConfig
             })
             ->end()
 
+            ->beginCommand('cleanup-unmaintained')
+            ->setDescription('Clean-up local branches marked as unmaintained (remote branches remain unchanged)')
+            ->setHandler(function () {
+                return new Handler\CleanupUnmaintainedHandler(
+                    $this->container['style'],
+                    $this->container['git'],
+                    $this->container['github'],
+                    $this->container['config']
+                );
+            })
+            ->end()
+
             ->beginCommand('checkout')
             ->setDescription('Checkout a pull request as local branch. Allows to push changes (unless disabled by author)')
             ->addArgument('number', Argument::INTEGER, 'Number of the pull request to checkout')

--- a/tests/Handler/CleanupUnmaintainedHandlerTest.php
+++ b/tests/Handler/CleanupUnmaintainedHandlerTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HuPKit package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace HubKit\Tests\Handler;
+
+use HubKit\Cli\Handler\CleanupUnmaintainedHandler;
+use HubKit\Config;
+use HubKit\Service\Git;
+use HubKit\Service\GitHub;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Webmozart\Console\Api\Args\Args;
+use Webmozart\Console\Api\Args\Format\ArgsFormat;
+use Webmozart\Console\Args\StringArgs;
+
+/**
+ * @internal
+ */
+final class CleanupUnmaintainedHandlerTest extends TestCase
+{
+    use ProphecyTrait;
+    use SymfonyStyleTrait;
+
+    private ObjectProphecy $git;
+    private ObjectProphecy $github;
+    private Config $config;
+
+    /** @before */
+    public function setUpCommandHandler(): void
+    {
+        $this->git = $this->prophesize(Git::class);
+        $this->git->getActiveBranchName()->willReturn('master');
+
+        $this->github = $this->prophesize(GitHub::class);
+        $this->github->getHostname()->willReturn('github.com');
+        $this->github->getOrganization()->willReturn('hubkit-sandbox');
+        $this->github->getRepository()->willReturn('empire');
+        $this->github->getAuthUsername()->willReturn('sstok');
+
+        $this->config = new Config([
+            'schema_version' => 2,
+            'github' => [
+                'github.com' => [
+                    'username' => 'sstok',
+                    'api_token' => 'CHANGE-ME',
+                ],
+            ],
+            '_local' => [
+                'branches' => [
+                    ':default' => [
+                        'split' => 'changed-only',
+                        'maintained' => false, // This is not even a valid config option, but we ignore this branch
+                    ],
+                    'master' => [
+                        'maintained' => true,
+                    ],
+                    '2.0' => [
+                        'maintained' => true,
+                    ],
+                    '1.5' => [
+                        'maintained' => false,
+                    ],
+                    '1.0' => [
+                        'maintained' => false,
+                    ],
+                ],
+            ],
+        ]);
+        $this->config->setActiveRepository('github.com', 'hubkit-sandbox/empire');
+    }
+
+    /** @test */
+    public function does_nothing_when_no_unmaintained_branches_found(): void
+    {
+        $this->git->branchExists('master')->willReturn(true);
+        $this->git->branchExists('2.0')->willReturn(true);
+        $this->git->branchExists(Argument::any())->willReturn(false);
+
+        $this->executeHandler();
+
+        $this->assertOutputMatches('No unmaintained branches found.');
+    }
+
+    /** @test */
+    public function removes_unmaintained_branches(): void
+    {
+        $this->git->branchExists('master')->willReturn(true);
+        $this->git->branchExists('2.0')->willReturn(true);
+        $this->git->branchExists('1.5')->willReturn(true);
+        $this->git->branchExists('1.0')->willReturn(true);
+        $this->git->deleteBranchWithForce('1.0')->shouldBeCalled();
+        $this->git->deleteBranchWithForce('1.5')->shouldBeCalled();
+
+        $this->executeHandler();
+
+        $this->assertOutputMatches([
+            'The following local branches are unmaintained and can be deleted.',
+            ' * 1.0',
+            ' * 1.5',
+            'Delete these local branches now?',
+            'Deleting branch "1.0"...',
+            'Deleting branch "1.5"...',
+        ]);
+        $this->assertOutputNotMatches(['Deleting branch "2.0"...']);
+    }
+
+    /** @test */
+    public function keeps_unmaintained_branches_when_aborted(): void
+    {
+        $this->git->branchExists('master')->willReturn(true);
+        $this->git->branchExists('2.0')->willReturn(true);
+        $this->git->branchExists('1.5')->willReturn(true);
+        $this->git->branchExists('1.0')->willReturn(true);
+        $this->git->deleteBranchWithForce('1.0')->shouldNotBeCalled();
+        $this->git->deleteBranchWithForce('1.5')->shouldNotBeCalled();
+
+        try {
+            $this->executeHandler(false);
+        } catch (\RuntimeException $e) {
+            self::assertSame('User aborted.', $e->getMessage());
+        }
+
+        $this->assertOutputMatches([
+            'The following local branches are unmaintained and can be deleted.',
+            ' * 1.0',
+            ' * 1.5',
+            'Delete these local branches now?',
+        ]);
+    }
+
+    private function getArgs(): Args
+    {
+        return new Args(ArgsFormat::build()->getFormat(), new StringArgs(''));
+    }
+
+    private function executeHandler(bool $confirm = true): void
+    {
+        $style = $this->createStyle($confirm ? ['yes'] : ['no']);
+        $handler = new CleanupUnmaintainedHandler(
+            $style,
+            $this->git->reveal(),
+            $this->github->reveal(),
+            $this->config,
+        );
+
+        $handler->handle($this->getArgs());
+    }
+}

--- a/tests/Handler/SymfonyStyleTrait.php
+++ b/tests/Handler/SymfonyStyleTrait.php
@@ -57,6 +57,10 @@ trait SymfonyStyleTrait
 
     protected function getDisplay(bool $normalize = true)
     {
+        if (! isset($this->output)) {
+            throw new \RuntimeException('No output available. Call createStyle() first.');
+        }
+
         rewind($this->output->getStream());
 
         $display = stream_get_contents($this->output->getStream());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | 
| Tickets       | 
| License       | MIT

A command to automatically cleanup old version branches (locally) to keep prevent working on unsupported versions.
Per recommendation of the Symfony contributing guide:

    When the support of a Project version branch ends, it's recommended
    to delete your local branch to avoid merging in it unawarely:

